### PR TITLE
Add My Doom Gruvbox (fix)

### DIFF
--- a/themes/doom-gruvbox-theme.el
+++ b/themes/doom-gruvbox-theme.el
@@ -59,7 +59,6 @@ background contrast. All other values default to \"medium\"."
    (magenta     '("#cc241d" "#cc241d" "magenta"))       ; red
    (violet      '("#d3869b" "#d3869b" "brightmagenta")) ; bright-purple
    (orange      '("#fe8019" "#fd971f" "orange"))        ; bright-orange
-   (my_orange   '("#d65d0e" "#d65d0e" "orange"))
    (yellow      '("#fabd2f" "#fabd2f" "yellow"))        ; bright-yellow
    (dark-yellow '("#d79921" "#fabd2f" "yellow"))        ; yellow
    (teal        '("#8ec07c" "#8ec07c" "green"))         ; bright-aqua
@@ -243,8 +242,8 @@ background contrast. All other values default to \"medium\"."
    (org-todo :foreground green :bold 'inherit)
    (org-verbatim :foreground yellow)
    ;;;; rainbow-delimiters
-   (rainbow-delimiters-depth-1-face :foreground my_orange)
-   (rainbow-delimiters-depth-2-face :foreground red)
+   (rainbow-delimiters-depth-1-face :foreground orange)
+   (rainbow-delimiters-depth-2-face :foreground magenta)
    (rainbow-delimiters-depth-3-face :foreground green)
    (rainbow-delimiters-depth-4-face :foreground blue)
    ;;;; show-paren <built-in>

--- a/themes/doom-gruvbox-theme.el
+++ b/themes/doom-gruvbox-theme.el
@@ -65,10 +65,10 @@ background contrast. All other values default to \"medium\"."
    (green       '("#b8bb26" "#b8bb26" "green"))         ; bright-green
    (dark-green  '("#98971a" "#98971a" "green"))         ; green
    (blue        '("#83a598" "#83a598" "brightblue"))    ; bright-blue
-   (my_blue     '("#318ce0" "#318ce0" "brightblue"))
+   (my-blue     '("#318ce0" "#318ce0" "brightblue"))
    (dark-blue   '("#458588" "#458588" "blue"))          ; blue
    (cyan        '("#8ec07c" "#8ec07c" "brightcyan"))    ; bright-aqua
-   (my-black    '("#37302f" "#37302f" "brightcyan"))
+   (my-black    '("#37302f" "#37302f" "black"))
    (dark-cyan   '("#689d6a" "#689d6a" "cyan"))          ; aqua
 
    ;; face categories
@@ -83,7 +83,7 @@ background contrast. All other values default to \"medium\"."
    (keywords       red)
    (methods        orange)
    (operators      yellow)
-   (type           my_blue)
+   (type           my-blue)
    (strings        green)
    (variables      blue)
    (numbers        violet)
@@ -226,6 +226,12 @@ background contrast. All other values default to \"medium\"."
    ((outline-6 &override) :foreground (doom-lighten violet 0.4))
    ((outline-7 &override) :foreground (doom-lighten dark-cyan 0.5))
    ((outline-8 &override) :foreground (doom-lighten violet 0.6))
+   ; ((outline-1 &override) :foreground green)
+   ; ((outline-2 &override) :foreground green)
+   ; ((outline-3 &override) :foreground yellow)
+   ; ((outline-4 &override) :foreground yellow)
+   ; ((outline-5 &override) :foreground dark-yellow)
+   ; ((outline-6 &override) :foreground dark-yellow)
    ;;;; org <built-in>
    (org-code :foreground orange)
    (org-date :foreground green)
@@ -236,10 +242,13 @@ background contrast. All other values default to \"medium\"."
    (org-formula :foreground green)
    (org-meta-line :foreground comments)
    (org-list-dt :foreground cyan)
+   ; (org-list-dt :foreground yellow)
    ((org-quote &override) :inherit 'italic :foreground base7 :background org-quote)
    (org-table :foreground cyan)
    (org-tag :foreground (doom-darken comments 0.15) :weight 'normal)
+   ; (org-tag :foreground yellow :bold nil)
    (org-todo :foreground green :bold 'inherit)
+   ; (org-todo :foreground yellow :bold 'inherit)
    (org-verbatim :foreground yellow)
    ;;;; rainbow-delimiters
    (rainbow-delimiters-depth-1-face :foreground orange)

--- a/themes/doom-gruvbox-theme.el
+++ b/themes/doom-gruvbox-theme.el
@@ -59,14 +59,17 @@ background contrast. All other values default to \"medium\"."
    (magenta     '("#cc241d" "#cc241d" "magenta"))       ; red
    (violet      '("#d3869b" "#d3869b" "brightmagenta")) ; bright-purple
    (orange      '("#fe8019" "#fd971f" "orange"))        ; bright-orange
+   (my_orange   '("#d65d0e" "#d65d0e" "orange"))
    (yellow      '("#fabd2f" "#fabd2f" "yellow"))        ; bright-yellow
    (dark-yellow '("#d79921" "#fabd2f" "yellow"))        ; yellow
    (teal        '("#8ec07c" "#8ec07c" "green"))         ; bright-aqua
    (green       '("#b8bb26" "#b8bb26" "green"))         ; bright-green
    (dark-green  '("#98971a" "#98971a" "green"))         ; green
    (blue        '("#83a598" "#83a598" "brightblue"))    ; bright-blue
+   (my_blue     '("#318ce0" "#318ce0" "brightblue"))
    (dark-blue   '("#458588" "#458588" "blue"))          ; blue
    (cyan        '("#8ec07c" "#8ec07c" "brightcyan"))    ; bright-aqua
+   (my-black    '("#37302f" "#37302f" "brightcyan"))
    (dark-cyan   '("#689d6a" "#689d6a" "cyan"))          ; aqua
 
    ;; face categories
@@ -77,11 +80,11 @@ background contrast. All other values default to \"medium\"."
    (comments       (if doom-gruvbox-brighter-comments magenta grey))
    (doc-comments   (if doom-gruvbox-brighter-comments (doom-lighten magenta 0.2) (doom-lighten fg-alt 0.25)))
    (constants      violet)
-   (functions      green)
+   (functions      orange)
    (keywords       red)
-   (methods        green)
-   (operators      fg)
-   (type           yellow)
+   (methods        orange)
+   (operators      yellow)
+   (type           my_blue)
    (strings        green)
    (variables      blue)
    (numbers        violet)
@@ -119,10 +122,10 @@ background contrast. All other values default to \"medium\"."
    ((link &override) :foreground violet)
    (minibuffer-prompt :foreground cyan)
    (mode-line
-    :background modeline-bg :foreground modeline-fg
+    :background my-black :foreground modeline-fg
     :box (if -modeline-pad `(:line-width ,-modeline-pad :color ,modeline-bg)))
    (mode-line-inactive
-    :background modeline-inactive-bg :foreground modeline-inactive-fg
+    :background bg :foreground base4
     :box (if -modeline-pad `(:line-width ,-modeline-pad :color ,modeline-inactive-bg)))
 
    ;;;; company
@@ -240,9 +243,9 @@ background contrast. All other values default to \"medium\"."
    (org-todo :foreground green :bold 'inherit)
    (org-verbatim :foreground yellow)
    ;;;; rainbow-delimiters
-   (rainbow-delimiters-depth-1-face :foreground orange)
+   (rainbow-delimiters-depth-1-face :foreground my_orange)
    (rainbow-delimiters-depth-2-face :foreground red)
-   (rainbow-delimiters-depth-3-face :foreground magenta)
+   (rainbow-delimiters-depth-3-face :foreground green)
    (rainbow-delimiters-depth-4-face :foreground blue)
    ;;;; show-paren <built-in>
    ((show-paren-match &override) :foreground nil :background base5 :bold t)
@@ -263,10 +266,10 @@ background contrast. All other values default to \"medium\"."
    (web-mode-json-key-face         :foreground green)
    (web-mode-json-context-face     :foreground cyan)
    ;;;; which-key
-   (which-func :foreground cyan)
-   (which-key-command-description-face :foreground fg)
-   (which-key-group-description-face :foreground (doom-lighten fg-alt 0.25))
-   (which-key-local-map-description-face :foreground cyan))
+   (which-key-key-face                   :foreground green)
+   (which-key-group-description-face     :foreground red)
+   (which-key-command-description-face   :foreground blue)
+   (which-key-local-map-description-face :foreground orange))
 
   ;;;; Base theme variable overrides
   ;; ()


### PR DESCRIPTION
Ok, after my previous PR (#614) , I realized that my doom-themes was out-of-date, and everything was looking broken so I decided to make my theme again from 0. The images look the same ( the look of my changes didn't change ), so it still seems like the images in #614.
I decided to break down my changes in  5 parts so you can I understand better what I changed: 

- **Added some colors**, I added 2 more colors based on morhetz's gruvbox theme (vim) which are a blue and black.
-  **Changed face categories**, Actually I changed functions, methods, operators, and type. But I changed them because they looked cool, it's not necessary to keep these.
- **Changed modeline's face**, In original doom-gruvbox the modeline looks like this:
![image](https://user-images.githubusercontent.com/61497342/120678282-2e4b3880-c4ad-11eb-912e-0ab699c965a7.png)
It's actually hard to recognize in which window you are + the modeline doesn't look well with other colors, so I changed it and now it looks like:
![image](https://user-images.githubusercontent.com/61497342/120678594-82561d00-c4ad-11eb-81de-504f743fb3d8.png)
- **Changed second depth of Rainbow delimiters face**, Currently rainbow delimiters's second and third faces are somehow not recognizable from each other as you can see here: 
![image](https://user-images.githubusercontent.com/61497342/120679905-f0e7aa80-c4ae-11eb-9215-0e434dd7f439.png)
So I changed it and now it looks like this:
![image](https://user-images.githubusercontent.com/61497342/120680744-ef6ab200-c4af-11eb-9222-079a0d31cc59.png)
- **And Finally I changed which-key faces**, right now, which-key faces are not obvious, so I added some colors to it.
Before: 
![image](https://user-images.githubusercontent.com/61497342/120681053-38226b00-c4b0-11eb-89c0-d10152c79cc8.png)
After:
![image](https://user-images.githubusercontent.com/61497342/120681093-41abd300-c4b0-11eb-8bb8-06adf62f8fe7.png)
 
 