### PR TITLE
Add Material Dark Theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ maintain them and address inconsistencies:
 | `doom-laserwave`                    | a clean 80's synthwave / outrun theme inspired by VS Code's [laserwave][laserwave] (thanks to [hyakt])       |
 | `doom-manegarm`                     | an original autumn-inspired dark theme (thanks to [kenranunderscore])                                        |
 | `doom-material`                     | adapted from [Material Themes] (thanks to [tam5])                                                            |
+| `doom-material-dark`                | adapted from [Material Dark Theme][Material Dark Theme] (thanks to [trev-dev][trev-dev])                     |
 | `doom-miramare`                     | a port of [Franbach's][franbach] [Miramare], a variant of gruvbox theme (thanks to [sagittaros])             |
 | `doom-molokai`                      | a theme based on Texmate's Monokai                                                                           |
 | `doom-monokai-classic`              | port of [Monokai]'s Classic variant (thanks to [ema2159])                                                    |
@@ -266,6 +267,8 @@ support.
 [LoveSponge]: https://github.com/LoveSponge
 [mateossh]: https://github.com/mateossh
 [Material Themes]: https://github.com/equinusocio/vsc-material-theme
+[Material Dark Theme]: https://github.com/xrei/material-dark-vscode
+[trev-dev]: https://github.com/trev-dev
 [minikN]: https://github.com/minikN
 [Miramare]: https://github.com/franbach/miramare
 [Moonlight Theme]: https://github.com/atomiks/moonlight-vscode-theme

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 A theme megapack for GNU Emacs, inspired by community favorites. Special
 attention is given for [Doom Emacs](https://doomemacs.org) and [solaire-mode]
-support, but will work fine anywhere else. 
+support, but will work fine anywhere else.
 
 [See the screenshots.][screenshots]
 
@@ -175,7 +175,7 @@ extensions][wiki].
   -  Fontify dividers/separators (5+ dashes)
   -  Fontify #hashtags and @at-tags, for personal convenience; see
      `doom-org-special-tags` to disable this.
-     
+
 ## Complimentary plugins
 The following plugins compliment our themes:
 
@@ -186,7 +186,7 @@ The following plugins compliment our themes:
   [airline-themes][airline-themes].
 - The modeline in the screenshots is
   [doom-modeline](https://github.com/seagle0128/doom-modeline).
-     
+
 ## Customization
 There are three ways to customize themes in this package:
 
@@ -201,21 +201,20 @@ There are three ways to customize themes in this package:
    + `doom-themes-padded-modeline` (default: `nil`): if `t`, pad the mode-line
      in 4px on each side. Can also be set to an integer to specify the exact
      padding.  or `M-x customize-group RET doom-themes` to explore them.
-  
+
 2. Use the `custom-set-faces` macro (Doom users should use `custom-set-faces!`
    instead) to customize any face. e.g.
-  
+
   ```elisp
   ;; Must be used *after* the theme is loaded
   (custom-set-faces
     `(mode-line ((t (:background ,(doom-color 'dark-violet)))))
     `(font-lock-comment-face ((t (:foreground ,(doom-color 'base6))))))
   ```
-  
+
 3. Copy your favorite theme into your `custom-theme-directory` (normally
    `~/.emacs.d/`, or `~/.doom.d/themes` for Doom users), and tweak it there.
-   
-  
+
 ## Contribute
 
 PRs are welcome to maintain our themes, including additional theme and plugin

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 A theme megapack for GNU Emacs, inspired by community favorites. Special
 attention is given for [Doom Emacs](https://doomemacs.org) and [solaire-mode]
-support, but will work fine anywhere else.
+support, but will work fine anywhere else. 
 
 [See the screenshots.][screenshots]
 
@@ -175,7 +175,7 @@ extensions][wiki].
   -  Fontify dividers/separators (5+ dashes)
   -  Fontify #hashtags and @at-tags, for personal convenience; see
      `doom-org-special-tags` to disable this.
-
+     
 ## Complimentary plugins
 The following plugins compliment our themes:
 
@@ -186,7 +186,7 @@ The following plugins compliment our themes:
   [airline-themes][airline-themes].
 - The modeline in the screenshots is
   [doom-modeline](https://github.com/seagle0128/doom-modeline).
-
+     
 ## Customization
 There are three ways to customize themes in this package:
 
@@ -201,20 +201,21 @@ There are three ways to customize themes in this package:
    + `doom-themes-padded-modeline` (default: `nil`): if `t`, pad the mode-line
      in 4px on each side. Can also be set to an integer to specify the exact
      padding.  or `M-x customize-group RET doom-themes` to explore them.
-
+  
 2. Use the `custom-set-faces` macro (Doom users should use `custom-set-faces!`
    instead) to customize any face. e.g.
-
+  
   ```elisp
   ;; Must be used *after* the theme is loaded
   (custom-set-faces
     `(mode-line ((t (:background ,(doom-color 'dark-violet)))))
     `(font-lock-comment-face ((t (:foreground ,(doom-color 'base6))))))
   ```
-
+  
 3. Copy your favorite theme into your `custom-theme-directory` (normally
    `~/.emacs.d/`, or `~/.doom.d/themes` for Doom users), and tweak it there.
-
+   
+  
 ## Contribute
 
 PRs are welcome to maintain our themes, including additional theme and plugin

--- a/doom-themes.el
+++ b/doom-themes.el
@@ -46,6 +46,7 @@
 ;;   + `doom-ir-black' (added by legendre6891)
 ;;   + `doom-laserwave' (added by hyakt)
 ;;   + `doom-material' (added by tam5)
+;;   + `doom-material-dark' (added by trev-dev)
 ;;   + `doom-manegarm' (added by kenranunderscore)
 ;;   + `doom-miramare' (added by sagittaros)
 ;;   + `doom-molokai' (added by hlissner)

--- a/themes/doom-material-dark-theme.el
+++ b/themes/doom-material-dark-theme.el
@@ -148,5 +148,7 @@ Can be an integer to determine the exact padding."
    ;;;; rjsx-mode
    (rjsx-tag :foreground red)
    (rjsx-attr :foreground yellow :slant 'italic :weight 'medium)))
+   ;;;; Treemacs
+   (treemacs-git-modified-face :foreground vc-modified)))
 
 ;;; doom-material-theme.el ends here

--- a/themes/doom-material-dark-theme.el
+++ b/themes/doom-material-dark-theme.el
@@ -6,6 +6,7 @@
   "Options for the `material dark' theme."
   :group 'doom-themes)
 
+
 (defcustom doom-material-padded-modeline doom-themes-padded-modeline
   "If non-nil, adds a 4px padding to the mode-line.
 Can be an integer to determine the exact padding."
@@ -148,10 +149,27 @@ Can be an integer to determine the exact padding."
    ;;;; rjsx-mode
    (rjsx-tag :foreground red)
    (rjsx-attr :foreground yellow :slant 'italic :weight 'medium)
+   (rjsx-tag-bracket-face :foreground cyan)
    ;;;; Magit
    (magit-header-line :background (doom-lighten modeline-bg 0.2) :foreground green :weight 'bold
                       :box `(:line-width 3 :color ,(doom-lighten modeline-bg 0.2)))
    ;;;; Treemacs
-   (treemacs-git-modified-face :foreground vc-modified)))
+   (treemacs-git-modified-face :foreground vc-modified)
+   ;;;; Web Mode
+   (web-mode-html-tag-face :foreground red)
+   (web-mode-html-attr-equal-face :foreground cyan)
+   ;;;; Org Mode
+   (org-level-1 :foreground green)
+   (org-level-2 :foreground yellow)
+   (org-level-3 :foreground red)
+   (org-level-4 :foreground cyan)
+   (org-level-5 :foreground blue)
+   (org-level-6 :foreground magenta)
+   (org-level-7 :foreground teal)
+   (org-level-8 :foreground violet)
+   ;;;; css
+   (css-property :foreground orange)
+   (css-proprietary-property :foreground magenta)
+   (css-selector :foreground yellow)))
 
 ;;; doom-material-theme.el ends here

--- a/themes/doom-material-dark-theme.el
+++ b/themes/doom-material-dark-theme.el
@@ -1,0 +1,149 @@
+;;; doom-material-dark-theme.el --- inspired by Material Theme by xrei -*- lexical-binding: t; no-byte-compile: t; -*-
+(require 'doom-themes)
+
+;;
+(defgroup doom-material-dark-theme nil
+  "Options for the `material dark' theme."
+  :group 'doom-themes)
+
+(defcustom doom-material-padded-modeline doom-themes-padded-modeline
+  "If non-nil, adds a 4px padding to the mode-line.
+Can be an integer to determine the exact padding."
+  :group 'doom-material-dark-theme
+  :type '(choice integer boolean))
+
+;;
+(def-doom-theme doom-material-dark
+  "A darker version of the Material Theme inspired by xrei"
+
+  ;; name        default   256       16
+  ((bg         '("#212121" nil       nil))
+   (bg-alt     '("#3e3e3e" nil       nil))
+   (base0      '("#171F24" "black"   "black"))
+   (base1      '("#262626" "#262626" "brightblack"))
+   (base2      '("#303030" "#303030" "brightblack"))
+   (base3      '("#3A3A3A" "#3A3A3A" "brightblack"))
+   (base4      '("#4a4a4a" "#444444" "brightblack"))
+   (base5      '("#585858" "#585858" "brightblack"))
+   (base6      '("#626262" "#626262" "brightblack"))
+   (base7      '("#767676" "#767676" "brightblack"))
+   (base8      '("#A8A8A8" "#a8a8a8" "white"))
+   (fg         '("#EEFFFF" "#e4e4e4" "brightwhite"))
+   (fg-alt     '("#BFC7D5" "#bcbcbc" "white"))
+
+   (grey base5)
+
+   (red         '("#f57373" "#ff0000" "red"))
+   (orange      '("#F78C6C" "#ff5f00" "brightred"))
+   (green       '("#c3e88d" "#afff00" "green"))
+   (teal        '("#44b9b1" "#00d7af" "brightgreen"))
+   (yellow      '("#ffcb6b" "#ffd700" "brightyellow"))
+   (blue        '("#82aaff" "#5fafff" "brightblue"))
+   (dark-blue   '("#7986E7" "#d7ffff" "blue"))
+   (magenta     '("#c792ea" "#d787d7" "brightmagenta"))
+   (violet      '("#bb80b3" "#d787af" "magenta"))
+   (cyan        '("#89DDFF" "#5fd7ff" "brightcyan"))
+   (dark-cyan   '("#80cbc4" "#00d7af" "cyan"))
+
+   ;; face categories -- required for all themes
+   (highlight      magenta)
+   (vertical-bar   base2)
+   (selection      base4)
+   (builtin        blue)
+   (comments       base6)
+   (doc-comments   base6)
+   (constants      orange)
+   (functions      blue)
+   (keywords       cyan)
+   (methods        blue)
+   (operators      cyan)
+   (type           magenta)
+   (strings        green)
+   (variables      yellow)
+   (numbers        orange)
+   (region         base3)
+   (error          red)
+   (warning        yellow)
+   (success        green)
+   (vc-modified    blue)
+   (vc-added       green)
+   (vc-deleted     red)
+
+   ;; custom categories
+   (modeline-bg     base2)
+   (modeline-bg-alt (doom-darken bg 0.01))
+   (modeline-fg     base8)
+   (modeline-fg-alt comments)
+
+   (-modeline-pad
+    (when doom-material-padded-modeline
+      (if (integerp doom-material-padded-modeline) doom-material-padded-modeline 4))))
+
+  ;;;; Base theme face overrides
+  (;;;; emacs
+   (lazy-highlight :background base4 :foreground fg :weight 'bold)
+   (mode-line
+    :background modeline-bg :foreground modeline-fg
+    :box (if -modeline-pad `(:line-width ,-modeline-pad :color ,modeline-bg)))
+   (mode-line-inactive
+    :background modeline-bg-alt :foreground modeline-fg-alt
+    :box (if -modeline-pad `(:line-width ,-modeline-pad :color ,modeline-bg-alt)))
+   (tooltip :background (doom-darken bg-alt 0.2) :foreground fg)
+   (cursor :background yellow)
+   (line-number-current-line
+     :inherit '(hl-line default)
+     :foreground cyan :distant-foreground nil
+     :weight 'normal :italic nil :underline nil :strike-through nil)
+
+   ;;;; doom-modeline
+   (doom-modeline-buffer-path       :foreground green :weight 'bold)
+   (doom-modeline-buffer-major-mode :inherit 'doom-modeline-buffer-path)
+   ;;;; highlight-thing highlight-symbol
+   (highlight-symbol-face :background region :distant-foreground fg-alt)
+   ;;;; highlight-thing
+   (highlight-thing :background region :distant-foreground fg-alt)
+   ;;;; man <built-in>
+   (Man-overstrike :inherit 'bold :foreground magenta)
+   (Man-underline :inherit 'underline :foreground blue)
+   ;;;; org <built-in>
+   ((org-block &override) :background base2)
+   ((org-block-background &override) :background base2)
+   ((org-block-begin-line &override) :background base2)
+   ;;;; css-mode <built-in> / scss-mode
+   (css-proprietary-property :foreground orange)
+   (css-property             :foreground green)
+   (css-selector             :foreground blue)
+   ;;;; dired-k
+   (dired-k-commited :foreground base4)
+   (dired-k-modified :foreground vc-modified)
+   (dired-k-ignored :foreground cyan)
+   (dired-k-added    :foreground vc-added)
+   ;;;; ivy
+   (ivy-current-match :background base3)
+   (ivy-minibuffer-match-face-2
+    :inherit 'ivy-minibuffer-match-face-1
+    :foreground dark-cyan :background base1 :weight 'semi-bold)
+   ;;;; js2-mode
+   (js2-jsdoc-tag              :foreground magenta)
+   (js2-object-property        :foreground yellow)
+   (js2-object-property-access :foreground cyan)
+   (js2-function-param         :foreground violet)
+   (js2-jsdoc-type             :foreground base8)
+   (js2-jsdoc-value            :foreground cyan)
+   ;;;; lsp
+   (lsp-headerline-breadcrumb-symbols-face :foreground base7)
+   ;;;; rainbow-delimiters
+   (rainbow-delimiters-depth-1-face :foreground magenta)
+   (rainbow-delimiters-depth-2-face :foreground orange)
+   (rainbow-delimiters-depth-3-face :foreground green)
+   (rainbow-delimiters-depth-4-face :foreground cyan)
+   (rainbow-delimiters-depth-5-face :foreground violet)
+   (rainbow-delimiters-depth-6-face :foreground yellow)
+   (rainbow-delimiters-depth-7-face :foreground blue)
+   (rainbow-delimiters-depth-8-face :foreground teal)
+   (rainbow-delimiters-depth-9-face :foreground dark-cyan)
+   ;;;; rjsx-mode
+   (rjsx-tag :foreground red)
+   (rjsx-attr :foreground yellow :slant 'italic :weight 'medium)))
+
+;;; doom-material-theme.el ends here

--- a/themes/doom-material-dark-theme.el
+++ b/themes/doom-material-dark-theme.el
@@ -84,7 +84,7 @@ Can be an integer to determine the exact padding."
   (;;;; emacs
    (lazy-highlight :background (doom-darken green 0.5) :foreground green :weight 'bold)
    (minibuffer-prompt :foreground yellow)
-   (region :background bg-alt :foreground nil :distant-foreground (doom-darken fg 0.2) :extend t)
+   (region :background (doom-darken dark-cyan 0.5) :foreground dark-cyan :distant-foreground (doom-darken fg 0.2) :extend t)
    (hl-line :background base2 :foreground nil)
    (mode-line
     :background modeline-bg :foreground modeline-fg
@@ -172,4 +172,4 @@ Can be an integer to determine the exact padding."
    (css-proprietary-property :foreground magenta)
    (css-selector :foreground yellow)))
 
-;;; doom-material-theme.el ends here
+;;; Doom-material-theme.el ends here

--- a/themes/doom-material-dark-theme.el
+++ b/themes/doom-material-dark-theme.el
@@ -81,7 +81,10 @@ Can be an integer to determine the exact padding."
 
   ;;;; Base theme face overrides
   (;;;; emacs
-   (lazy-highlight :background base4 :foreground fg :weight 'bold)
+   (lazy-highlight :background (doom-darken green 0.5) :foreground green :weight 'bold)
+   (minibuffer-prompt :foreground yellow)
+   (region :background bg-alt :foreground nil :distant-foreground (doom-darken fg 0.2) :extend t)
+   (hl-line :background base2 :foreground nil)
    (mode-line
     :background modeline-bg :foreground modeline-fg
     :box (if -modeline-pad `(:line-width ,-modeline-pad :color ,modeline-bg)))

--- a/themes/doom-material-dark-theme.el
+++ b/themes/doom-material-dark-theme.el
@@ -147,7 +147,10 @@ Can be an integer to determine the exact padding."
    (rainbow-delimiters-depth-9-face :foreground dark-cyan)
    ;;;; rjsx-mode
    (rjsx-tag :foreground red)
-   (rjsx-attr :foreground yellow :slant 'italic :weight 'medium)))
+   (rjsx-attr :foreground yellow :slant 'italic :weight 'medium)
+   ;;;; Magit
+   (magit-header-line :background (doom-lighten modeline-bg 0.2) :foreground green :weight 'bold
+                      :box `(:line-width 3 :color ,(doom-lighten modeline-bg 0.2)))
    ;;;; Treemacs
    (treemacs-git-modified-face :foreground vc-modified)))
 


### PR DESCRIPTION
Material Dark Theme

As close as I could get it in an afternoon to the theme it's inspired by: https://github.com/xrei/material-dark-vscode

![Screenshot from 2021-07-30 16-10-53](https://user-images.githubusercontent.com/28788713/127720176-ffd4f110-c1f2-4d85-984f-b3234e7ef388.png)

This theme is a lot like the included material theme. Thanks go to @tam5 for providing the source that was my starting point.

The theme features an overall darker background and makes broader use of red/yellow/green.