### PR TITLE
Make window splits more visible for oceanic-next-theme

### DIFF
--- a/themes/doom-oceanic-next-theme.el
+++ b/themes/doom-oceanic-next-theme.el
@@ -61,7 +61,7 @@ determine the exact padding."
 
    ;; face categories -- required for all themes
    (highlight      yellow)
-   (vertical-bar   (doom-darken base1 0.5))
+   (vertical-bar   (doom-darken base4 0.25))
    (selection      base2)
    (builtin        red)
    (comments       (if doom-oceanic-next-brighter-comments dark-cyan base3))


### PR DESCRIPTION
This small change makes divisions between windows more visible.

Before:
![image](https://user-images.githubusercontent.com/7918794/141167230-48ae55a8-5232-4239-9872-1cbc290bdead.png)

After:
![image](https://user-images.githubusercontent.com/7918794/141168616-9b5147d4-5e26-4c18-8bab-ff14826baaf1.png)

That's it!

