### PR TITLE
Revert gruvbox-dark code-font changes from #616

### DIFF
--- a/themes/doom-gruvbox-theme.el
+++ b/themes/doom-gruvbox-theme.el
@@ -65,7 +65,6 @@ background contrast. All other values default to \"medium\"."
    (green       '("#b8bb26" "#b8bb26" "green"))         ; bright-green
    (dark-green  '("#98971a" "#98971a" "green"))         ; green
    (blue        '("#83a598" "#83a598" "brightblue"))    ; bright-blue
-   (my-blue     '("#318ce0" "#318ce0" "brightblue"))
    (dark-blue   '("#458588" "#458588" "blue"))          ; blue
    (cyan        '("#8ec07c" "#8ec07c" "brightcyan"))    ; bright-aqua
    (my-black    '("#37302f" "#37302f" "black"))
@@ -79,11 +78,11 @@ background contrast. All other values default to \"medium\"."
    (comments       (if doom-gruvbox-brighter-comments magenta grey))
    (doc-comments   (if doom-gruvbox-brighter-comments (doom-lighten magenta 0.2) (doom-lighten fg-alt 0.25)))
    (constants      violet)
-   (functions      orange)
+   (functions      green)
    (keywords       red)
-   (methods        orange)
-   (operators      yellow)
-   (type           my-blue)
+   (methods        green)
+   (operators      fg)
+   (type           yellow)
    (strings        green)
    (variables      blue)
    (numbers        violet)


### PR DESCRIPTION
Hey,

I use `doom-gruvbox-dark`, and https://github.com/doomemacs/themes/pull/616 recently improved the theme. I think that most changes were really good (specially the modeline ones), but I dislike the new code faces. The main reason is how _jumpy_ the new `my_blue` is. I don't think it blends well with the rest of the colorscheme and it is a significant deviation from [the original colorscheme](https://github.com/morhetz/gruvbox/wiki/Gallery). 

From @ItsNilDev 's pr:
> Changed face categories, Actually I changed functions, methods, operators, and type. But I changed them because they looked cool, it's not necessary to keep these.

 
Current theme:
![jumpy_blue](https://user-images.githubusercontent.com/27872944/147973178-aee2f56f-67c3-44f8-895d-738838b61121.png)
![mu4e](https://user-images.githubusercontent.com/27872944/147973185-25a7b678-3f10-4eea-8744-1da7597c79c1.png)

Old/reverted code faces:

![jumpy_blue_no](https://user-images.githubusercontent.com/27872944/147973202-ce040b62-2765-4434-8d36-5d4425d905cb.png)
![mu4e_no](https://user-images.githubusercontent.com/27872944/147973208-3c3ce70a-444d-4f89-8b94-10c7df3d6d0e.png)

I understand that this is quite subjective, but I feel like most users would prefer the theme that more closely resembles the original (?) If other users prefer the new faces / don't care, sorry for the bother and feel free to close this pr.
