### PR TITLE
Fix illegible org blocks: doom-tokyo-night

### DIFF
--- a/themes/doom-tokyo-night-theme.el
+++ b/themes/doom-tokyo-night-theme.el
@@ -248,8 +248,8 @@
 
    ;;; org-mode
    (org-hide :foreground hidden)
-   (org-block :background base2)
-   (org-block-begin-line :background base2 :foreground comments)
+   (org-block :background (doom-darken base2 0.65))
+   (org-block-begin-line :background (doom-darken base2 0.65) :foreground comments :extend t)
    (solaire-org-hide-face :foreground hidden)
 
    ;;; web-mode


### PR DESCRIPTION

## Before:
![tokyo-before](https://user-images.githubusercontent.com/53148859/148226994-4533e8e3-ba3b-4a4a-b5f9-2c391a10dacb.png)

## After:
![tokyo-after](https://user-images.githubusercontent.com/53148859/148227055-6972560a-c2a2-40de-b529-9fc7b59ff75c.png)

Fixes the illegible colour of org-blocks that stands out and causes issues when reading commented/greyed out characters.
