### PR TITLE
fix(ext-visual-bell): Make it work with emacs 29

### DIFF
--- a/extensions/doom-themes-ext-visual-bell.el
+++ b/extensions/doom-themes-ext-visual-bell.el
@@ -22,15 +22,21 @@
 ;;;###autoload
 (defun doom-themes-visual-bell-fn ()
   "Blink the mode-line red briefly. Set `ring-bell-function' to this to use it."
-  (let ((doom-themes--bell-cookie (face-remap-add-relative 'mode-line 'doom-themes-visual-bell)))
+  ;; Since emacs 29, the mode-line face is the parent of the new face
+  ;; mode-line-active and mode-line-inactive.  For remapping purposes, the
+  ;; mode-line-active face has to be used, see details at:
+  ;; http://debbugs.gnu.org/cgi/bugreport.cgi?bug=53636
+  (let* ((face (if (facep 'mode-line-active)
+                   'mode-line-active
+                 'mode-line))
+         (buf (current-buffer))
+         (cookie (face-remap-add-relative face 'doom-themes-visual-bell)))
     (force-mode-line-update)
     (run-with-timer 0.15 nil
-                    (lambda (cookie buf)
+                    (lambda ()
                       (with-current-buffer buf
                         (face-remap-remove-relative cookie)
-                        (force-mode-line-update)))
-                    doom-themes--bell-cookie
-                    (current-buffer))))
+                        (force-mode-line-update))))))
 
 ;;;###autoload
 (defun doom-themes-visual-bell-config ()


### PR DESCRIPTION
Since emacs 29 (the current git master), the `mode-line` face is the parent of the new face `mode-line-active` and `mode-line-inactive`.  For remapping purposes, the `mode-line-active` face has to be used, see details at:

http://debbugs.gnu.org/cgi/bugreport.cgi?bug=53636

I've also took the leisure to add a closure to the timer instead of providing arguments to the timer function since the package requires emacs 25.1 anyhow, so support for `lexical-binding` can be assumed.