### PR TITLE
fix(gruvbox-light) make gray readable

### DIFF
--- a/doom-themes-base.el
+++ b/doom-themes-base.el
@@ -1374,8 +1374,6 @@
     ;;;; volatile-highlights
     (vhl/default-face :background grey)
     ;;;; vterm
-    (vterm               :foreground fg)
-    (vterm-color-default :foreground fg)
     (vterm-color-black   :background (doom-lighten base0 0.25)   :foreground base0)
     (vterm-color-red     :background (doom-lighten red 0.25)     :foreground red)
     (vterm-color-green   :background (doom-lighten green 0.25)   :foreground green)

--- a/themes/doom-gruvbox-light-theme.el
+++ b/themes/doom-gruvbox-light-theme.el
@@ -474,8 +474,6 @@ background contrast. All other values default to \"medium\"."
     :background modeline-bg-inactive-l
     :box (if -modeline-pad `(:line-width ,-modeline-pad :color ,modeline-bg-inactive-l)))
    ;;;; vterm
-   (vterm               :foreground fg)
-   (vterm-color-default :foreground fg)
    (vterm-color-black   :background grey    :foreground base1)
    (vterm-color-red     :background red     :foreground faded-red)
    (vterm-color-green   :background green   :foreground faded-green)

--- a/themes/doom-gruvbox-light-theme.el
+++ b/themes/doom-gruvbox-light-theme.el
@@ -473,6 +473,17 @@ background contrast. All other values default to \"medium\"."
     :inherit 'mode-line-inactive
     :background modeline-bg-inactive-l
     :box (if -modeline-pad `(:line-width ,-modeline-pad :color ,modeline-bg-inactive-l)))
+   ;;;; vterm
+   (vterm               :foreground fg)
+   (vterm-color-default :foreground fg)
+   (vterm-color-black   :background grey    :foreground base1)
+   (vterm-color-red     :background red     :foreground faded-red)
+   (vterm-color-green   :background green   :foreground faded-green)
+   (vterm-color-yellow  :background yellow  :foreground faded-yellow)
+   (vterm-color-blue    :background blue    :foreground faded-blue)
+   (vterm-color-magenta :background violet  :foreground magenta)
+   (vterm-color-cyan    :background cyan    :foreground faded-aqua)
+   (vterm-color-white   :background base7   :foreground light4)
    ;;;; web-mode
    (web-mode-current-element-highlight-face :background dark-blue :foreground bg)
    ;;;; wgrep <built-in>

--- a/themes/doom-solarized-dark-high-contrast-theme.el
+++ b/themes/doom-solarized-dark-high-contrast-theme.el
@@ -217,8 +217,6 @@ Can be an integer to determine the exact padding."
     :background modeline-bg-inactive-alt
     :box (if -modeline-pad `(:line-width ,-modeline-pad :color ,modeline-bg-inactive-alt)))
    ;;;; vterm
-   (vterm               :foreground fg)
-   (vterm-color-default :foreground fg)
    (vterm-color-black   :background (doom-lighten base0 0.75)   :foreground base0)
    (vterm-color-red     :background (doom-lighten red 0.75)     :foreground red)
    (vterm-color-green   :background (doom-lighten green 0.75)   :foreground green)


### PR DESCRIPTION
This makes gray readable by way of overriding vterm colors to match the
kitty terminal's gruvbox-light theme
https://github.com/kovidgoyal/kitty-themes/blob/6b06ed8661c62b1fcc63c9de9054d9cc12c319f6/themes/gruvbox-light.conf,
which itself is using colors from the upstream gruvbox palette
https://camo.githubusercontent.com/d080d9c204408ef06b862b76bc795f930b3a9b1be4c5d2de149f1d8eb765b660/687474703a2f2f692e696d6775722e636f6d2f3439714b7959572e706e67.

Unfortunately the variable names associated with this palette are all
over the place in this theme.

Before:
<img width="185" alt="before" src="https://user-images.githubusercontent.com/5225653/157604369-ca1a38e9-d0d4-4efc-98b6-0c377af3ccd9.png">

After:
<img width="187" alt="after" src="https://user-images.githubusercontent.com/5225653/157604380-40d1a8e0-7e63-491b-86f3-f51b7a178fed.png">

(I have no idea why fish's set_color prints them in this order...)
