### PR TITLE
org-mode: align list items in mixed-pitch-mode

### DIFF
--- a/extensions/doom-themes-ext-org.el
+++ b/extensions/doom-themes-ext-org.el
@@ -115,8 +115,13 @@ N is the match index."
              ;; Make checkbox statistic cookies respect underlying faces
              '(("\\[\\([0-9]*%\\)\\]\\|\\[\\([0-9]*\\)/\\([0-9]*\\)\\]"
                 (0 (org-get-checkbox-statistics-face) prepend))
-               ;; make plain list bullets stand out
-               ("^ *\\([-+]\\|\\(?:[0-9]+\\|[a-zA-Z]\\)[).]\\)[ \t]" 1 'org-list-dt append)
+               ;; make plain list bullets stand out.
+               ;; give spaces before and after list bullet org-indent face to
+               ;; keep correct indentation on mixed-pitch-mode
+               ("^\\( *\\)\\([-+]\\|\\(?:[0-9]+\\|[a-zA-Z]\\)[).]\\)\\([ \t]\\)"
+                (1 'org-indent append)
+                (2 'org-list-dt append)
+                (3 'org-indent append))
                ;; and separators/dividers
                ("^ *\\(-----+\\)$" 1 'org-meta-line))
              ;; I like how org-mode fontifies checked TODOs and want this to


### PR DESCRIPTION
This pull request fixes the alignment of list items in org-mode when using `mixed-pitch-mode` or similar modes like doom's zen mode. It does so by giving the space characters before the list bullet item and the single space after the bullet item the `org-indent` face.

Org buffer with standard fixed-pitch font:
![scr-b](https://user-images.githubusercontent.com/543132/159928318-df553d6a-7b5d-46fb-be8f-783742ea3f6d.png)

Org buffer with doom's zen mode activated before the patch:
![scr-a](https://user-images.githubusercontent.com/543132/159928297-c99cb31c-11b8-43c4-8c3c-56fb6dd113f2.png)

Org buffer with doom's zen mode activated after the patch:
![scr-c](https://user-images.githubusercontent.com/543132/159928329-8b9664b0-f3bf-4d81-92a4-fd16289b048d.png)

