### PR TITLE
fix(ext-neotree): restore missing icons

### DIFF
--- a/extensions/doom-themes-ext-neotree.el
+++ b/extensions/doom-themes-ext-neotree.el
@@ -212,7 +212,7 @@ incorrectly, so remove them."
                                :family ,(all-the-icons-octicon-family)
                                :height 1.3)
               'display '(raise 0)))
-            (t (all-the-icons-icon-for-file node)))
+            (t (all-the-icons-icon-for-file (neo-path--file-short-name node))))
     (all-the-icons-fileicon "default")))
 
 (defun doom--neotree-insert-dir-icon (node type &optional faces)


### PR DESCRIPTION
<!-- ⚠️ Please do not ignore this template! -->

Fixes an old issue where some icons are missing with 
`(setq doom-themes-neotree-file-icons t)`

Fix: https://github.com/doomemacs/themes/issues/180#issuecomment-739877395

Before:
![emacs_2022-05-12_21-11-12](https://user-images.githubusercontent.com/60074051/168095640-4b6bc1bf-0d43-4883-bd50-237dd02ba515.png)

After:
![image](https://user-images.githubusercontent.com/60074051/168096001-00ac3253-ee93-4358-aca2-a4493169e465.png)

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [x] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
