### PR TITLE
tweak(vibrant): use more vivid color for variables

### DIFF
--- a/themes/doom-vibrant-theme.el
+++ b/themes/doom-vibrant-theme.el
@@ -94,7 +94,7 @@ Can be an integer to determine the exact padding."
    (operators      magenta)
    (type           yellow)
    (strings        green)
-   (variables      base8)
+   (variables      (doom-lighten magenta 0.4))
    (numbers        orange)
    (region         "#3d4451")
    (error          red)


### PR DESCRIPTION
Hey

Using `doom-vibrant` was difficult on this yaml file, due to the color of `font-lock-variable-name-face`
So i reverted the `base8` color of `variables` to the value from `doom-one`. 

There might be another way to approach this, changing the yaml mode and, but i this was the path of least resistance for me.
If this helps anyone else, this PR exists

Before:
![Doom-vibrant-before](https://user-images.githubusercontent.com/3420234/178672984-cbf67946-70cd-406e-ad28-cb50c0142f1d.png)
After:
![Doom-vibrant-after](https://user-images.githubusercontent.com/3420234/178672977-acefd8f1-4326-4ec4-a8f8-390ebdd99d80.png)



-----
- [X] I searched the issue tracker and this hasn't been PRed before.
- [X] My changes are visual; I've included before and after screenshots.
- [X] Any relevant issues or PRs have been linked to.
