### PR TITLE
Fix link in README Table of Contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ support, but will work fine anywhere else.
 # Table of Contents
 - [Install](#install)
     - [Doom Emacs](#doom-emacs)
-    - [Manually](#manually)
+    - [Manually](#manually--use-package)
 - [Theme list](#theme-list)
     - [Flagship themes](#flagship-themes)
     - [Additional themes](#additional-themes)


### PR DESCRIPTION
<!-- ⚠️ Please do not ignore this template! -->
Link `#manually` should point to `#manually--use-package` in the README Table of Contents

Fixes #740

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [x] Any relevant issues or PRs have been linked to.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
