### PR TITLE
feat(base): add symbol-overlay faces

### DIFF
--- a/doom-themes-base.el
+++ b/doom-themes-base.el
@@ -1307,6 +1307,18 @@
     (stripe-highlight
      (&light :background base5)
      (&dark  :background base3))
+    ;;;; symbol-overlay
+    (symbol-overlay-default-face
+     (&dark  :background (doom-lighten region 0.1) :distant-foreground fg-alt)
+     (&light :background (doom-darken region 0.1)  :distant-foreground fg-alt))
+    (symbol-overlay-face-1 :background (doom-blend blue bg 0.4)    :distant-foreground fg-alt)
+    (symbol-overlay-face-2 :background (doom-blend violet bg 0.4)  :distant-foreground fg-alt)
+    (symbol-overlay-face-3 :background (doom-blend yellow bg 0.3)  :distant-foreground fg-alt)
+    (symbol-overlay-face-4 :background (doom-blend orange bg 0.3)  :distant-foreground fg-alt)
+    (symbol-overlay-face-5 :background (doom-blend red bg 0.3)     :distant-foreground fg-alt)
+    (symbol-overlay-face-6 :background (doom-blend magenta bg 0.3) :distant-foreground fg-alt)
+    (symbol-overlay-face-7 :background (doom-blend green bg 0.4)   :distant-foreground fg-alt)
+    (symbol-overlay-face-8 :background (doom-blend cyan bg 0.2)    :distant-foreground fg-alt)
     ;;;; swiper
     (swiper-line-face    :background blue    :foreground base0)
     (swiper-match-face-1 :inherit 'unspecified :background base0   :foreground base5)


### PR DESCRIPTION
Based on the faces for highlight-symbol, with some reasonable looking choices
for the extra faces symbol-overlay has compared to highlight-symbol.