### PR TITLE
ext-treemacs: add pom.xml

### DIFF
--- a/extensions/doom-themes-ext-treemacs.el
+++ b/extensions/doom-themes-ext-treemacs.el
@@ -229,7 +229,7 @@ Only takes effect if `doom-themes-treemacs-enable-variable-pitch' is non-nil."
                       "ini" "inputrc" "json" "ledgerrc" "lock" "nginx"
                       "npm-shrinkwrap.json" "npmignore" "npmrc"
                       "package-lock.json" "package.json" "phpunit" "pkg" "plist"
-                      "properties" "terminalrc" "toml" "tridactylrc"
+                      "pom.xom" "properties" "terminalrc" "toml" "tridactylrc"
                       "vimperatorrc" "vimrc" "vrapperrc" "xdefaults" "xml"
                       "xresources" "yaml" "yarn-integrity" "yarnclean"
                       "yarnignore" "yarnrc" "yml"))


### PR DESCRIPTION
pom.xml is not displaying properly in doom treemacs because it is listed explicitly in the treemacs icons code but not listed in the doom treemacs theme as an extension.  

- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [x] My changes are visual; I've included before and after screenshots.

Before:
![Screen_Shot_2022-08-29_at_1 51 31_PM](https://user-images.githubusercontent.com/146446/187479167-6f58b227-6b6a-4446-95d5-675e376d321a.png)

After
![Screen Shot 2022-08-30 at 11 05 41 AM](https://user-images.githubusercontent.com/146446/187479208-c632c033-c5be-495e-8070-13fff2445e77.png)

