### PR TITLE
docs: fix #customize link in project readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ support, but will work fine anywhere else.
     - [Planned themes](#planned-themes)
 - [Extensions](#extensions)
 - [Complementary plugins](#complementary-plugins)
-- [FAQ](#faq)
+- [Customization](#customization)
 - [Contribute](#contribute)
 
 ## Install


### PR DESCRIPTION
Link #faq should be replaced by #customize in the README Table of Contents.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
