### PR TITLE
feat(base): add mm-uu-extract face

### DIFF
--- a/doom-themes-base.el
+++ b/doom-themes-base.el
@@ -995,6 +995,8 @@
     ;;;; minimap
     (minimap-current-line-face :background selection)
     (minimap-active-region-background :background vertical-bar)
+    ;; mm
+    (mm-uu-extract :background (doom-blend highlight base2 0.07) :foreground (doom-blend highlight fg 0.15))
     ;;;; mmm-mode
     (mmm-init-submode-face :background (doom-blend red bg 0.1))
     (mmm-cleanup-submode-face :background (doom-blend yellow bg 0.1))


### PR DESCRIPTION
By default, `mm-uu-extract` has a `light yellow` foreground and `dark green` background. It's a bit garish.

Before:
![image](https://user-images.githubusercontent.com/20903656/192683300-2b56c26c-2517-4dee-9f9b-b2e36d147716.png)

Here's an attempt to make this fit in a bit nicer.

**vibrant**

![image](https://user-images.githubusercontent.com/20903656/192686570-eb757194-2bab-4bf3-b9e7-fd2bfdd81dda.png)

**solarised dark**

![image](https://user-images.githubusercontent.com/20903656/192686601-0d7ecc00-cf3b-4d0f-b70a-0bcfd3e40127.png)

**spacegrey**

![image](https://user-images.githubusercontent.com/20903656/192686629-5d9c3e06-bb7f-4229-b8da-c8c9f626a709.png)

**one light**

![image](https://user-images.githubusercontent.com/20903656/192686668-5b9520e5-4b24-41ef-a2d0-3f974c098349.png)

**dracula**

![image](https://user-images.githubusercontent.com/20903656/192686707-3a2c7a70-ffac-4cb5-b4b0-4001344a0292.png)

**horizon**

![image](https://user-images.githubusercontent.com/20903656/192686884-29865f94-1712-453a-a439-561b845f3195.png)

**nord**

![image](https://user-images.githubusercontent.com/20903656/192686747-4003e0a9-7c3b-4b85-bbbc-47b3c6d7c9d5.png)

**nord light**

![image](https://user-images.githubusercontent.com/20903656/192686792-cfdf96b0-2b7a-4024-b4cc-9765ca8b325c.png)

**gruvbox**

![image](https://user-images.githubusercontent.com/20903656/192686855-7a0aba38-b617-4808-8ce9-1f391d425ea5.png)


**gruvbox light**

![image](https://user-images.githubusercontent.com/20903656/192686829-6ea08bb9-624b-42b6-92e5-e4221758a60e.png)


-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [x] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.
- [ ] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

