### PR TITLE
feat(base): add disk-usage faces

### DIFF
--- a/doom-themes-base.el
+++ b/doom-themes-base.el
@@ -469,6 +469,11 @@
     (diredfl-symlink                :foreground violet)
     (diredfl-tagged-autofile-name   :foreground base5)
     (diredfl-write-priv             :foreground red)
+    ;;;; disk-usage
+    (disk-usage-children            :foreground yellow)
+    (disk-usage-percent             :foreground violet)
+    (disk-usage-size                :foreground blue)
+    (disk-usage-symlink             :foreground cyan :weight 'bold)
     ;;;; doom-modeline
     (doom-modeline-eldoc-bar :background green)
     (doom-modeline-bar-inactive) ; transparent


### PR DESCRIPTION
https://elpa.gnu.org/packages/disk-usage.html

Before:

Same as after but all elements using the `default` face (all white in this particular case)

After:

(using `doom-tomorrow-night`)

![image](https://user-images.githubusercontent.com/131893/192992808-e5beff38-2fe9-40b2-b079-f79ca2c92b89.png)

`disk-usage-symlink` mimics what doom-themes does to `dired-symlink` for consistency.