### PR TITLE
docs: fix docstring for some themes

### DIFF
--- a/themes/doom-henna-theme.el
+++ b/themes/doom-henna-theme.el
@@ -45,7 +45,7 @@ determine the exact padding."
 ;;; Theme definition
 
 (def-doom-theme doom-henna
-  "A dark theme inspired by Atom One Dark"
+  "A dark theme inspired by VSCode's Henna theme"
 
   ;; name        default   256       16
   ((bg         '("#21272e" nil       nil            ))

--- a/themes/doom-homage-black-theme.el
+++ b/themes/doom-homage-black-theme.el
@@ -34,7 +34,7 @@ determine the exact padding."
 ;;; Theme definition
 
 (def-doom-theme doom-homage-black
-  "A light theme inspired by Atom One"
+  "A light theme inspired by eziam"
 
   ;; name        default   256       16
   ((bg         '("#000000" nil       nil            ))

--- a/themes/doom-homage-white-theme.el
+++ b/themes/doom-homage-white-theme.el
@@ -34,7 +34,7 @@ determine the exact padding."
 ;;; Theme definition
 
 (def-doom-theme doom-homage-white
-  "A light theme inspired by Atom One"
+  "A light theme inspired by editors from 2000s"
 
   ;; name        default   256       16
   ((bg         '("#fafafa" nil       nil            ))

--- a/themes/doom-wilmersdorf-theme.el
+++ b/themes/doom-wilmersdorf-theme.el
@@ -29,7 +29,7 @@ determine the exact padding."
 ;;; Theme definition
 
 (def-doom-theme doom-wilmersdorf
-  "A dark theme inspired by Atom City Lights"
+  "A dark theme inspired by Ian Pan's Wilmersdorf"
 
   ;; name        default   256       16
   ((bg         '("#282b33" "#282b33" nil            ))


### PR DESCRIPTION
I updated the descriptions of Doom-Henna, Doom-Homage-Black Doom, Doom-Homage-White, and Doom Wilmersdorf. I didn't think this was worthy of creating an issue for so I decided to just complete the fix my self.

Fixes #0000
References #0000
Replaces #0000

-----
- [/] I searched the issue tracker and this hasn't been PRed before.
- [/] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [/] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [/] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.
- [/] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.