### PR TITLE
feat(base): add font-lock-number-face

### DIFF
--- a/doom-themes-base.el
+++ b/doom-themes-base.el
@@ -41,6 +41,7 @@
     (font-lock-string-face               :foreground strings)
     (font-lock-type-face                 :foreground type)
     (font-lock-variable-name-face        :foreground variables)
+    (font-lock-number-face               :foreground numbers)
     (font-lock-warning-face              :inherit 'warning)
     (font-lock-negation-char-face        :inherit 'bold :foreground operators)
     (font-lock-preprocessor-face         :inherit 'bold :foreground operators)


### PR DESCRIPTION
According to Emacs 29.1, they introduce new face for number but this themes doesn't support it yet.

Fixes #771

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ ] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.