### PR TITLE
fix: handle all nil => unspecified cases

### DIFF
--- a/doom-themes.el
+++ b/doom-themes.el
@@ -206,8 +206,8 @@
       (maphash (lambda (face plist)
                  (when (keywordp (car plist))
                    ;; TODO Clean up duplicates in &all/&light/&dark blocks
-                   (dolist (prop (append (unless doom-themes-enable-bold   '(:weight normal :bold nil))
-                                         (unless doom-themes-enable-italic '(:slant normal :italic nil))))
+                   (dolist (prop (append (unless doom-themes-enable-bold   '(:weight normal :bold 'unspecified))
+                                         (unless doom-themes-enable-italic '(:slant normal :italic 'unspecified))))
                      (when (and (plist-member plist prop)
                                 (not (eq (plist-get plist prop) 'inherit)))
                        (plist-put plist prop
@@ -429,8 +429,8 @@ theme face specs. These is a simplified spec. For example:
         ',name ,@(doom-themes-prepare-facelist extra-faces))
        (custom-theme-set-variables
         ',name ,@(doom-themes-prepare-varlist extra-vars))
-       (unless bold (set-face-bold 'bold nil))
-       (unless italic (set-face-italic 'italic nil))
+       (unless bold (set-face-bold 'bold 'unspecified))
+       (unless italic (set-face-italic 'italic 'unspecified))
        (provide-theme ',name))))
 
 ;;;###autoload
@@ -440,6 +440,25 @@ theme face specs. These is a simplified spec. For example:
     (add-to-list 'custom-theme-load-path
                  (or (and (file-directory-p dir) dir)
                      base))))
+
+(defun doom-themes--custom-set-unspecified (fn theme &rest args)
+  (cl-labels
+      ((nil-or-unspecified
+         (val)
+         (cond
+          ((null val) 'unspecified)
+          ((listp val) (mapcar #'nil-or-unspecified val))
+          (t val)))
+       (make-unspecified
+         (spec)
+         (if (null (cadr spec))
+             spec
+           (mapcar #'nil-or-unspecified spec))))
+    (apply fn theme (if (listp args)
+                        (mapcar #'make-unspecified args)
+                      args))))
+
+(advice-add 'custom-theme-set-faces :around #'doom-themes--custom-set-unspecified)
 
 (provide 'doom-themes)
 ;;; doom-themes.el ends here


### PR DESCRIPTION
A recent change to Emacs 29 makes setting a face attribute to nil now
throw a warning, so using some advice we recur through a face spec (only
when there's a valid spec) and change all the nils to 'unspecified.

I'm aware this probably isn't the _best_ way to handle it, I'm open to suggestions here.

Fixes: #753