### PR TITLE
fix(acario-dark): 'nil value is invalid' warnings

### DIFF
--- a/themes/doom-acario-dark-theme.el
+++ b/themes/doom-acario-dark-theme.el
@@ -108,7 +108,7 @@ determine the exact padding."
     (when doom-acario-dark-padded-modeline
       (if (integerp doom-acario-dark-padded-modeline) doom-acario-dark-padded-modeline 4)))
 
-   (modeline-fg     nil)
+   (modeline-fg     'unspecified)
    (modeline-fg-alt base7)
 
    (modeline-bg
@@ -127,7 +127,9 @@ determine the exact padding."
   ((font-lock-comment-face
     :slant 'italic
     :foreground comments
-    :background (if doom-acario-dark-comment-bg (doom-lighten bg 0.05)))
+    :background (if doom-acario-dark-comment-bg
+                    (doom-lighten bg 0.05)
+                  'unspecified))
    (font-lock-doc-face
     :inherit 'font-lock-comment-face
     :foreground doc-comments)


### PR DESCRIPTION
Avoids
```
Warning: setting attribute ‘:foreground’ of face ‘mode-line’: nil value is invalid, use ‘unspecified’ instead.
Warning: setting attribute ‘:background’ of face ‘font-lock-comment-face’: nil value is invalid, use ‘unspecified’ instead.
```


These changes are pretty trivial, but is user facing since it pollutes `*Messages*`.

Related: https://github.com/doomemacs/themes/pull/777/files
However, it misses both cases I've addressed here. So a continuation of: https://github.com/doomemacs/themes/issues/753

I won't promise to get all of them, only the two that bothered me.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [ ] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ ] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.
