### PR TITLE
Xcode function color

### DIFF
--- a/themes/doom-xcode-theme.el
+++ b/themes/doom-xcode-theme.el
@@ -71,7 +71,7 @@ Can be an integer to determine the exact padding."
    (comments       grey)
    (doc-comments   (doom-lighten grey 0.14))
    (constants      violet)
-   (functions      dark-blue)
+   (functions      magenta)
    (keywords       pink)
    (methods        dark-blue)
    (operators      orange)

--- a/themes/doom-xcode-theme.el
+++ b/themes/doom-xcode-theme.el
@@ -113,12 +113,12 @@ Can be an integer to determine the exact padding."
    (doom-modeline-buffer-path       :foreground dark-blue :bold bold)
    (doom-modeline-buffer-major-mode :inherit 'doom-modeline-buffer-path)
    ;;;; rainbow-delimiters
-   (rainbow-delimiters-depth-1-face :foreground violet)
+   (rainbow-delimiters-depth-1-face :foreground yellow)
    (rainbow-delimiters-depth-2-face :foreground blue)
    (rainbow-delimiters-depth-3-face :foreground orange)
    (rainbow-delimiters-depth-4-face :foreground green)
    (rainbow-delimiters-depth-5-face :foreground magenta)
-   (rainbow-delimiters-depth-6-face :foreground yellow)
+   (rainbow-delimiters-depth-6-face :foreground violet)
    (rainbow-delimiters-depth-7-face :foreground teal))
 
   ;; --- variables --------------------------


### PR DESCRIPTION
<!-- ⚠️ Please do not ignore this template! -->

Emacs 29's `python-ts-mode` is presented in the screenshot, the first window is the original (note `obj.hello`), second window is after adjusting function face, third window is after adjusting rainbow-delimiters.

The window to the right is [VScode - Xcode classic dark](https://marketplace.visualstudio.com/items?itemName=MateoCERQUETELLA.xcode-12-theme) taken for reference (because I don't have access the "real" Xcode).

![image](https://github.com/doomemacs/themes/assets/32123754/090e5f38-6d72-498d-96b8-0357adae51fc)


Fixes #788
-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [x] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
