### PR TITLE
fix: Invisible ivy-current-match in doom-1337

### DIFF
--- a/themes/doom-1337-theme.el
+++ b/themes/doom-1337-theme.el
@@ -170,7 +170,7 @@ Can be an integer to determine the exact padding."
    (doom-themes-treemacs-file-face :foreground fg)
    ;;;; ivy
    (counsel-active-mode :foreground (doom-lighten base6 0.1))
-   (ivy-current-match :background bg)
+   (ivy-current-match :background bg-alt)
    (ivy-minibuffer-match-face-2 :foreground (doom-lighten base6 0.1) :weight 'extra-bold)
    ;;;; js2-mode
    (js2-jsdoc-tag              :foreground magenta)


### PR DESCRIPTION
<!-- ⚠️ Please do not ignore this template! -->

On `doom-1337`, face `ivy-current-match` is `bg`.

This means that one cannot see the currently selected completion in Ivy.

Commit fixes this visibility and usability issue. See before and after images. `bg` -> `bg-alt`.

Before:
![Untitled](https://github.com/doomemacs/themes/assets/26366643/e202f4bc-0204-4fcb-bc50-bb2b1e6f9577)
_Which completion is selected? No idea._

After:
![Untitled3](https://github.com/doomemacs/themes/assets/26366643/d1704ea9-4b64-4125-b322-f6540015a62c)
_Current selection is lightly highlighted (consistent with rest of theme)._

Thank you!

-----
- [X] I searched the issue tracker and this hasn't been PRed before.
- [X] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [X] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [X] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.
- [X] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->