### PR TITLE
tweak(monokai-pro): change line-number color base4->base5

### DIFF
--- a/themes/doom-monokai-pro-theme.el
+++ b/themes/doom-monokai-pro-theme.el
@@ -130,7 +130,7 @@ Can be an integer to determine the exact padding."
    (doom-modeline-buffer-path       :foreground blue :bold bold)
    (doom-modeline-buffer-major-mode :inherit 'doom-modeline-buffer-path)
 
-   ((line-number &override) :foreground base4)
+   ((line-number &override) :foreground base5)
    ((line-number-current-line &override) :foreground yellow :bold bold)
 
    ;;;; rainbow-delimiters


### PR DESCRIPTION
Line numbers with base4 color is hardly visible on screen, changing to base5 as in e.g. monokai-classic.

Here is a screenshoot of the change (left is base4 as un the theme and right is base5 as in this PR):

![image](https://github.com/doomemacs/themes/assets/191528/ae8608de-006d-4f53-8281-94a704c96b96)


Fix: #796 
Ref: #796 
Close: #796

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [ ] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [x] My changes are visual; I've included before and after screenshots.
- [x] Any relevant issues or PRs have been linked to.
