### PR TITLE
fix(base): inherit 'isearch for lsp-ui-peek-highlight

### DIFF
--- a/doom-themes-base.el
+++ b/doom-themes-base.el
@@ -1129,7 +1129,7 @@
     (lsp-ui-peek-selection :foreground bg :background blue :bold bold)
     (lsp-ui-peek-list :background (doom-darken bg 0.1))
     (lsp-ui-peek-peek :background (doom-darken bg 0.1))
-    (lsp-ui-peek-highlight :inherit 'lsp-ui-peek-header :background region :foreground bg :box t)
+    (lsp-ui-peek-highlight :inherit 'isearch :box t)
     (lsp-ui-peek-line-number :foreground success)
     (lsp-ui-sideline-code-action :foreground (doom-blend highlight bg 0.85))
     (lsp-ui-sideline-current-symbol :inherit 'highlight)
@@ -1419,7 +1419,7 @@
     (tldr-description      :foreground fg :weight 'semi-bold)
     (tldr-introduction     :foreground (doom-blend blue bg 0.8) :weight 'semi-bold)
     (tldr-code-block       :foreground green :background region :weight 'semi-bold)
-    (tldr-command-argument :foreground fg :background region )
+    (tldr-command-argument :foreground fg :background region)
     ;;;; typescript-mode <modes:typescript-mode,typescript-tsx-mode>
     (typescript-jsdoc-tag :foreground doc-comments)
     (typescript-jsdoc-type :foreground (doom-darken doc-comments 0.15))
@@ -1542,9 +1542,9 @@
     ;;;; xref <built-in>
     ((xref-file-header &inherit compilation-info))
     ((xref-line-number &inherit compilation-line-number))
-    ((xref-match &inherit match))
+    ((xref-match &inherit match)))
     ;;;; --- END Package faces ------------------
-    )
+    
   "TODO")
 
 ;;;; --- Package variables ------------------


### PR DESCRIPTION
<!-- ⚠️ Please do not ignore this template! -->

Using 'isearch ensures that the highlight is visible in most themes,
while keeping the same semantics as "searching for a particular string
everywhere".

Close: #766
Ref: #766
Co-Authored-By: @ianyepan 

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [x] My changes are visual; I've included before and after screenshots.
  Changes are in the linked issue
- [ ] I am blindly checking these off.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
