### PR TITLE
fix(ayu): make org-macro legible

### DIFF
--- a/themes/doom-ayu-dark-theme.el
+++ b/themes/doom-ayu-dark-theme.el
@@ -220,6 +220,7 @@ determine the exact padding."
    (org-hide :foreground hidden)
    (org-headline-done :foreground syntax-comment)
    (org-document-info-keyword :foreground comments)
+   (org-macro :foreground syntax-operator)
    ;;;; mic-paren
    ((paren-face-match &override) :foreground fg :background ui-selection-bg :weight 'ultra-bold)
    ;;;; rjsx-mode

--- a/themes/doom-ayu-light-theme.el
+++ b/themes/doom-ayu-light-theme.el
@@ -213,6 +213,7 @@ determine the exact padding."
    (org-hide :foreground hidden)
    (org-headline-done :foreground syntax-comment)
    (org-document-info-keyword :foreground comments)
+   (org-macro :foreground syntax-operator)
    ;;;; rjsx-mode
    (rjsx-tag :foreground cyan)
    (rjsx-tag-bracket-face :foreground (doom-lighten cyan 0.5))

--- a/themes/doom-ayu-mirage-theme.el
+++ b/themes/doom-ayu-mirage-theme.el
@@ -211,6 +211,7 @@ determine the exact padding."
    (org-hide :foreground hidden)
    (org-headline-done :foreground syntax-comment)
    (org-document-info-keyword :foreground comments)
+   (org-macro :foreground syntax-operator)
    ;;;; mic-paren
    ((paren-face-match &override) :foreground fg :background ui-selection-bg :weight 'ultra-bold)
    ;;;; rjsx-mode


### PR DESCRIPTION
This makes `org-macro` legible across the `ayu` themes.

## Before

`ayu-mirage`:
<img width="133" alt="image" src="https://github.com/doomemacs/themes/assets/66708316/a953de42-a95f-4585-beef-2c40762b2943">

`ayu-dark`:
<img width="133" alt="image" src="https://github.com/doomemacs/themes/assets/66708316/3103adc4-ce2b-448a-bcdf-4af3e82b9eaa">

`ayu-light`:
<img width="133" alt="image" src="https://github.com/doomemacs/themes/assets/66708316/fe51f19d-0ac3-4cd4-9d16-2a4eb00c52b5">

## After

`ayu-mirage`:
<img width="133" alt="image" src="https://github.com/doomemacs/themes/assets/66708316/aa4eae9f-b9d4-41fd-8753-311e0f9075dc">

`ayu-dark`:
<img width="133" alt="image" src="https://github.com/doomemacs/themes/assets/66708316/b822248b-8d12-4932-b0d9-d661a24af137">

`ayu-light`:
<img width="133" alt="image" src="https://github.com/doomemacs/themes/assets/66708316/97b9f31e-d4ce-414c-95c5-82b633ef831a">


-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [x] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.