### PR TITLE
tweak(monokai): make regions in org blocks visible

### DIFF
--- a/themes/doom-monokai-classic-theme.el
+++ b/themes/doom-monokai-classic-theme.el
@@ -178,6 +178,9 @@ determine the exact padding."
    ((org-quote &override) :inherit 'italic :foreground base7 :background org-quote)
    (org-todo :foreground yellow :bold 'inherit)
    (org-list-dt :foreground yellow)
+   ((org-block &override) :background base2)
+   ((org-block-background &override) :background base2)
+   ((org-block-begin-line &override) :background base2)
    ;;;; rainbow-delimiters
    (rainbow-delimiters-depth-1-face :foreground magenta)
    (rainbow-delimiters-depth-2-face :foreground orange)

--- a/themes/doom-monokai-machine-theme.el
+++ b/themes/doom-monokai-machine-theme.el
@@ -214,6 +214,9 @@ Can be an integer to determine the exact padding."
    ((org-quote &override)                        :inherit 'italic :foreground base7 :background org-quote)
    (org-todo                                     :foreground yellow)
    (org-list-dt                                  :foreground yellow)
+   ((org-block &override) :background base2)
+   ((org-block-background &override) :background base2)
+   ((org-block-begin-line &override) :background base2)
    ;;;;;; php-mode
    (php-php-tag                                  :foreground orange)
    (php-function-name                            :foreground green)

--- a/themes/doom-monokai-octagon-theme.el
+++ b/themes/doom-monokai-octagon-theme.el
@@ -212,6 +212,9 @@ Can be an integer to determine the exact padding."
    ((org-quote &override)                        :inherit 'italic :foreground base7 :background org-quote)
    (org-todo                                     :foreground yellow :bold 'inherit)
    (org-list-dt                                  :foreground yellow)
+   ((org-block &override) :background base2)
+   ((org-block-background &override) :background base2)
+   ((org-block-begin-line &override) :background base2)
    ;;;;;; php-mode
    (php-php-tag                                  :foreground orange)
    (php-function-name                            :foreground green)

--- a/themes/doom-monokai-ristretto-theme.el
+++ b/themes/doom-monokai-ristretto-theme.el
@@ -224,6 +224,9 @@ Can be an integer to determine the exact padding."
    ((org-quote &override)                        :inherit 'italic :foreground base7 :background org-quote)
    (org-todo                                     :foreground yellow :bold 'inherit)
    (org-list-dt                                  :foreground yellow)
+   ((org-block &override) :background base2)
+   ((org-block-background &override) :background base2)
+   ((org-block-begin-line &override) :background base2)
    ;;;; php-mode
    (php-php-tag                                  :foreground orange)
    (php-function-name                            :foreground green)

--- a/themes/doom-monokai-spectrum-theme.el
+++ b/themes/doom-monokai-spectrum-theme.el
@@ -213,6 +213,9 @@ Can be an integer to determine the exact padding."
    ((org-quote &override)                        :inherit 'italic :foreground base7 :background org-quote)
    (org-todo                                     :foreground yellow :bold 'inherit)
    (org-list-dt                                  :foreground yellow)
+   ((org-block &override) :background base2)
+   ((org-block-background &override) :background base2)
+   ((org-block-begin-line &override) :background base2)
    ;;;; php-mode
    (php-php-tag                                  :foreground orange)
    (php-function-name                            :foreground green)


### PR DESCRIPTION
Adds override for face `org-block` to avoid a region within the block begin indistinguishable from the block's background. Uses face `base2` for `org-block{-background,-begin-line]}`.

Theme `doom-theme-monokai-pro` was not included since it doesn't have this problem.

* themes/doom-monokai-classic-theme.el
* themes/doom-monokai-machine-theme.el
* themes/doom-monokai-octagon-theme.el
* themes/doom-monokai-ristretto-theme.el
* themes/doom-monokai-spectrum-theme.el

Fix: #762
-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [x] My changes are visual; I've included before and after screenshots.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

# Screenshot

Using `doom-monokai-machine` as an example.

## Before

![machine-before](https://github.com/doomemacs/themes/assets/12915439/a3a560a2-9b42-4f25-8147-10d84ff4afcf)

## After
![machine-after](https://github.com/doomemacs/themes/assets/12915439/819dc9b6-3c9f-4f36-beb4-107f5aa466f2)
