### PR TITLE
feat(neotree): replace all-the-icons by nerd-icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ common defaults laid out:
 
   ;; Enable flashing mode-line on errors
   (doom-themes-visual-bell-config)
-  ;; Enable custom neotree theme (all-the-icons must be installed!)
+  ;; Enable custom neotree theme (nerd-icons must be installed!)
   (doom-themes-neotree-config)
   ;; or for treemacs users
   (setq doom-themes-treemacs-theme "doom-atom") ; use "doom-colors" for less minimal icon theme
@@ -157,8 +157,8 @@ extensions][wiki].
   file drawer; a more minimalistic icon theme plus variable pitch file/directory
   labels, as seen [in the doom-one screenshot](/../screenshots/doom-one.png).
 
-  (This requires `all-the-icons`' fonts to be installed: `M-x
-  all-the-icons-install-fonts`)
+  (This requires `nerd-icons`' fonts to be installed: `M-x
+  nerd-icons-install-fonts`)
 - `(doom-themes-treemacs-config)`: two [treemacs] icon themes, one that takes after
   [Atom]'s, and a second more colorful implementation.
 - `(doom-themes-org-config)`: corrects and improves some of org-mode's native
@@ -228,7 +228,7 @@ support.
 [airline-doom-molokai]: https://github.com/AnthonyDiGirolamo/airline-themes/raw/master/screenshots/airline-doom-molokai-theme.png
 [airline-doom-one]: https://github.com/AnthonyDiGirolamo/airline-themes/raw/master/screenshots/airline-doom-one-theme.png
 [airline-themes]: https://github.com/AnthonyDiGirolamo/airline-themes
-[all-the-icons]: https://github.com/domtronn/all-the-icons.el
+[nerd-icons]: https://github.com/rainstormstudio/nerd-icons.el
 [ar1a]: https://github.com/ar1a
 [ashton]: https://github.com/ashton
 [bigardone]: https://github.com/bigardone

--- a/extensions/doom-themes-ext-neotree.el
+++ b/extensions/doom-themes-ext-neotree.el
@@ -80,7 +80,7 @@ depending on whether the folder is a repo, symlink or regular folder."
 
 (defun doom-themes--neo-is-repo-dir-p (path)
   (or (file-exists-p (format "%s/.git" path))
-      (all-the-icons-dir-is-submodule path)))
+      (nerd-icons-dir-is-submodule path)))
 
 (defvar doom-themes-neotree-dir-rules
   (eval-when-compile
@@ -89,33 +89,33 @@ depending on whether the folder is a repo, symlink or regular folder."
       ("/\\.[^$/#]+$"
        :face doom-themes-neotree-hidden-file-face)
       (file-symlink-p
-       :icon (all-the-icons-octicon "file-symlink-directory"))
+       :icon (nerd-icons-octicon "nf-oct-file_symlink_directory"))
       (doom-themes--neo-is-repo-dir-p
-       :icon (all-the-icons-octicon "file-submodule"))
-      (t :icon (all-the-icons-octicon "file-directory"))))
+       :icon (nerd-icons-octicon "nf-oct-file_submodule"))
+      (t :icon (nerd-icons-octicon "nf-oct-file_directory"))))
   "TODO")
 
 (defvar doom-themes-neotree-file-rules
   (eval-when-compile
     `((file-symlink-p
-       :icon (all-the-icons-octicon "file-symlink-file"))
+       :icon (nerd-icons-octicon "nf-oct-file_symlink_file"))
       (file-executable-p
        :face doom-themes-neotree-executable-file-face
-       :icon (all-the-icons-octicon "file-binary"))
+       :icon (nerd-icons-octicon "nf-oct-file_binary"))
       ("\\.\\(?:md\\|org\\|rst\\|log\\)\\|/[A-Z_-]+\\(?:\\.[a-z]+\\)?$"
        :face doom-themes-neotree-text-file-face
-       :icon (all-the-icons-octicon "file-text"))
+       :icon (nerd-icons-octicon "nf-oct-file"))
       (,(concat "\\." (regexp-opt '("htm" "html" "phtml" "tpl" "erb" "mustache"
                                     "twig" "ejs" "erb" "jsx" "haml" "inky-haml"
                                     "inky-slim" "slim" "pug" "jade"))
                 "$")
-       :icon (all-the-icons-octicon "file-code"))
+       :icon (nerd-icons-octicon "nf-oct-file_code"))
       (,(concat "\\(?:/\\(?:Gemfile\\|Vagrantfile\\|Makefile\\|Rakefile\\|Cask\\|\\.[^$]+rc\\|\\)\\|"
                 "\\." (regexp-opt '("json" "cson" "yaml" "yml" "xml" "toml"
                                     "tpl" "ini" "erb" "mustache" "twig" "ejs"
                                     "mk" "haml" "pug" "jade"))
                 "\\)$")
-       :icon (all-the-icons-octicon "file-code"))
+       :icon (nerd-icons-octicon "nf-oct-file_code"))
       (,(concat "\\."
                 (regexp-opt '("png" "jpg" "jpeg" "gif" "ico" "tif" "tiff"
                               "svg" "bmp" "psd" "ai" "eps" "indd"         ; images
@@ -123,19 +123,16 @@ depending on whether the folder is a repo, symlink or regular folder."
                               "wav" "mp3" "ogg" "midi"))                  ; audio
                 "$")
        :face doom-themes-neotree-data-file-face
-       :icon (all-the-icons-octicon "file-media"))
+       :icon (nerd-icons-octicon "nf-oct-file_media"))
       (,(concat "\\.\\(?:[gl]?zip\\|bzip2\\|deb\\|dmg\\|iso\\|7z\\|rpm\\|pkg\\|dat\\|[rjt]ar\\(?:\\.gz\\)?\\)$")
        :face doom-themes-neotree-data-file-face
-       :icon (all-the-icons-octicon "file-zip"))
-      ("\\.pdf$"
-       :face doom-themes-neotree-data-file-face
-       :icon (all-the-icons-octicon "file-pdf"))
+       :icon (nerd-icons-octicon "nf-oct-file_zip"))
       ("\\.\\(?:lock\\|resolved\\|dll\\|so\\|pyc\\|elc\\|class\\|css\\.map\\)$"
        :face doom-themes-neotree-hidden-file-face
-       :icon (all-the-icons-octicon "file-binary"))
+       :icon (nerd-icons-octicon "nf-oct-file_binary"))
       ("/\\.[^$/#]+$"
        :face doom-themes-neotree-hidden-file-face)
-      (t :icon (all-the-icons-octicon "file-text"))))
+      (t :icon (nerd-icons-octicon "nf-oct-file"))))
   "TODO")
 
 
@@ -207,35 +204,35 @@ incorrectly, so remove them."
              (propertize
               (if icon
                   (apply (car icon) (cdr icon))
-                (all-the-icons-octicon "file-text"))
+                (nerd-icons-octicon "nf-oct-file"))
               'face `(:inherit ,faces
-                               :family ,(all-the-icons-octicon-family)
-                               :height 1.3)
+                      :family ,(nerd-icons-octicon-family)
+                      :height 1.3)
               'display '(raise 0)))
-            (t (all-the-icons-icon-for-file (neo-path--file-short-name node))))
-    (all-the-icons-fileicon "default")))
+            (t (nerd-icons-icon-for-file (neo-path--file-short-name node))))
+    (nerd-icons-fileicon "default")))
 
 (defun doom--neotree-insert-dir-icon (node type &optional faces)
   (concat (if type
-              (all-the-icons-octicon
-               (format "chevron-%s" (if (eq type 'open) "down" "right"))
+              (nerd-icons-octicon
+               (format "nf-oct-chevron_%s" (if (eq type 'open) "down" "right"))
                :v-adjust 0.1
                :height doom-themes-neotree-chevron-size
                :face `(:inherit ,faces
-                                :family ,(all-the-icons-octicon-family)
-                                :height ,doom-themes-neotree-chevron-size))
+                       :family ,(nerd-icons-octicon-family)
+                       :height ,doom-themes-neotree-chevron-size))
             "\t")
           "\t"
           (when doom-themes-neotree-enable-folder-icons
-            (all-the-icons-octicon
-             (cond ((file-symlink-p node) "file-symlink-directory")
-                   ((file-exists-p (format "%s/.git" node)) "file-submodule")
-                   ((all-the-icons-dir-is-submodule node) "file-submodule")
-                   ("file-directory"))
+            (nerd-icons-octicon
+             (cond ((file-symlink-p node) "nf-oct-file_symlink_directory")
+                   ((file-exists-p (format "%s/.git" node)) "nf-oct-file_submodule")
+                   ((nerd-icons-dir-is-submodule node) "nf-oct-file_submodule")
+                   ("nf-oct-file_directory"))
              :v-adjust 0
              :height doom-themes-neotree-folder-size
              :face `(:inherit ,faces
-                     :family ,(all-the-icons-octicon-family)
+                     :family ,(nerd-icons-octicon-family)
                      :height ,doom-themes-neotree-folder-size)))))
 
 (defun doom--neotree-insert-icon (type node &optional icon faces)
@@ -275,8 +272,8 @@ incorrectly, so remove them."
   (when (display-graphic-p)
     (insert
      (concat (propertize "\t" 'face 'neo-root-dir-face)
-             (all-the-icons-octicon
-              "repo"
+             (nerd-icons-octicon
+              "nf-oct-repo"
               :height doom-themes-neotree-project-size
               :face 'neo-root-dir-face
               :v-adjust -0.1)
@@ -359,8 +356,8 @@ incorrectly, so remove them."
 ;;; Bootstrap
 
 (with-eval-after-load 'neotree
-  (unless (require 'all-the-icons nil t)
-    (error "all-the-icons isn't installed"))
+  (unless (require 'nerd-icons nil t)
+    (error "nerd-icons isn't installed"))
 
   ;; Incompatible with this theme
   (setq neo-vc-integration nil)


### PR DESCRIPTION
I have issues when missing all-the-icons and nerd-icons. It seems that nerd-icons is the new thing, so I updated neotree extension to use it, and it seems to work fine here (both in simple and normal mode)

Related https://github.com/doomemacs/themes/issues/263

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [x] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

![image](https://github.com/doomemacs/themes/assets/421352/3bb93205-6ca4-4554-a9b4-2efca3ca15c0)