### PR TITLE
Fix: show-paren fg val from 'nil' to 'unspecified'

### DIFF
--- a/themes/doom-gruvbox-theme.el
+++ b/themes/doom-gruvbox-theme.el
@@ -270,8 +270,8 @@ background contrast. All other values default to \"medium\"."
    (rainbow-delimiters-depth-3-face :foreground green)
    (rainbow-delimiters-depth-4-face :foreground blue)
    ;;;; show-paren <built-in>
-   ((show-paren-match &override) :foreground nil :background base5 :bold t)
-   ((show-paren-mismatch &override) :foreground nil :background "red")
+   ((show-paren-match &override) :foreground 'unspecified :background base5 :bold t)
+   ((show-paren-mismatch &override) :foreground 'unspecified :background "red")
    ;;;; swiper
    (swiper-line-face :background bg-alt2)
    ;;;; undo-tree


### PR DESCRIPTION
This commit fixes a warning Emacs sends regarding the foreground value being set to nil for show-paren faces in the gruvbox theme.

The faces that cause the warning are: 'show-paren-match' and 'show-paren-mismatch'.
Instead of setting it to nil, it is now 'unspecified'.

Common issue it seems like with the new changes to Emacs.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [ ] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).

