### PR TITLE
fix(org): compat with org-modern horizontal rules

### DIFF
--- a/extensions/doom-themes-ext-org.el
+++ b/extensions/doom-themes-ext-org.el
@@ -46,12 +46,21 @@ See `doom-themes-org-fontify-special-tags'."
   :type '(repeat symbol)
   :group 'doom-themes-org)
 
+(defcustom doom-themes-org-fontify-horizontal-rules t
+  "If non-nil, fontify horizontal rules defined by 5 or more dashes."
+  :type 'boolean
+  :group 'doom-themes-org)
+
 (defface doom-themes-org-at-tag '((t :inherit org-formula))
   "Face used to fontify @-tags in org-mode."
   :group 'doom-themes-org)
 
 (defface doom-themes-org-hash-tag '((t :inherit org-tag))
   "Face used to fontify #hashtags in org-mode."
+  :group 'doom-themes-org)
+
+(defface doom-themes-org-horizontal-rule '((t :inherit org-meta-line))
+  "Face used to fontify horizontal rules in org-mode."
   :group 'doom-themes-org)
 
 
@@ -120,9 +129,10 @@ N is the match index."
                ("^\\( *\\)\\([-+]\\|\\(?:[0-9]+\\|[a-zA-Z]\\)[).]\\)\\([ \t]\\)"
                 (1 'org-indent append)
                 (2 'org-list-dt append)
-                (3 'org-indent append))
+                (3 'org-indent append)))
+             (when doom-themes-org-fontify-horizontal-rules
                ;; and separators/dividers
-               ("^ *\\(-----+\\)$" 1 'org-meta-line))
+               '(("^ *\\(-----+\\)$" 1 'doom-themes-org-horizontal-rule)))
              ;; I like how org-mode fontifies checked TODOs and want this to
              ;; extend to checked checkbox items:
              (when org-fontify-done-headline


### PR DESCRIPTION
`org-modern` fontifies horizontal rules using `org-modern-horizontal-rule`.
doom-themes does so too but using `org-meta-line` before `org-modern` does it.

to resolve this conflict, add a switch to disable doom-themes fontifications.

since I introduced a new face, it should not cause any change by default.

Ref: minad/org-modern#59
Ref: minad/org-modern#145

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ ] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.