### PR TITLE
fix(molokai): line-number distant-fg - change `nil` -> `'unspecified`

### DIFF
--- a/themes/doom-molokai-theme.el
+++ b/themes/doom-molokai-theme.el
@@ -125,8 +125,8 @@ Can be an integer to determine the exact padding."
   ;;;; Base theme face overrides
   ((cursor :background magenta)
    (lazy-highlight :background violet :foreground base0 :distant-foreground base0 :bold bold)
-   ((line-number &override) :foreground base5 :distant-foreground nil)
-   ((line-number-current-line &override) :foreground base7 :distant-foreground nil)
+   ((line-number &override) :foreground base5 :distant-foreground 'unspecified)
+   ((line-number-current-line &override) :foreground base7 :distant-foreground 'unspecified)
    (mode-line
     :background modeline-bg :foreground modeline-fg
     :box (if -modeline-pad `(:line-width ,-modeline-pad :color modeline-bg)))


### PR DESCRIPTION
Similar to #818. Removes the warnings:
```
Warning: setting attribute ‘:distant-foreground’ of face ‘line-number-current-line’: nil value is invalid, use ‘unspecified’ instead.
Warning: setting attribute ‘:distant-foreground’ of face ‘line-number’: nil value is invalid, use ‘unspecified’ instead.
```

Partially fixes #793, Molokai was at least mentioned on this comment https://github.com/doomemacs/themes/issues/793#issuecomment-1946109346

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ ] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
