### PR TITLE
doom-nova visual modifications

### DIFF
--- a/themes/doom-nova-theme.el
+++ b/themes/doom-nova-theme.el
@@ -89,9 +89,9 @@ determine the exact padding."
    ;; custom categories
    (current-line    base5) ; (doom-lighten bg-alt 0.04)
    (modeline-fg     blue)
-   (modeline-bg     base5) ; bg-alt
+   (modeline-bg     base3)
    (modeline-fg-alt (doom-lighten bg-alt 0.4))
-   (modeline-bg-alt base4)
+   (modeline-bg-alt bg-alt)
 
    (-modeline-pad
     (when doom-nova-padded-modeline
@@ -152,7 +152,9 @@ determine the exact padding."
    (rainbow-delimiters-depth-6-face :foreground yellow)
    (rainbow-delimiters-depth-7-face :foreground teal)
    ;;;; solaire-mode
-   (solaire-hl-line-face :inherit 'hl-line))
+   (solaire-hl-line-face :inherit 'hl-line)
+   ;;;; vertico
+   (vertico-current :background base5))
 
   ;; --- variables --------------------------
   ;; ()


### PR DESCRIPTION
<!-- ⚠️ Please do not ignore this template! -->

Changes some of the faces for the doom-nova theme.

1. The inactive mode line color is lightened to provide a separation between horizontal splits
2. The active mode line color is darkened (preference only)
3. The current vertico selection is darkened so text is readable

Changes:
![image](https://github.com/doomemacs/themes/assets/23609591/4f95b273-56a4-4b36-8cf8-73f416369c34)

To:
![image](https://github.com/doomemacs/themes/assets/23609591/29b45f8d-4a1d-40d3-bfa1-4e37960c42d2)

- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [x] My changes are visual; I've included before and after screenshots.
