### PR TITLE
theme: Add support for window-tool-bar, added in Emacs 30

### DIFF
--- a/doom-themes-base.el
+++ b/doom-themes-base.el
@@ -1527,6 +1527,10 @@
     (window-divider :inherit 'vertical-border)
     (window-divider-first-pixel :inherit 'window-divider)
     (window-divider-last-pixel  :inherit 'window-divider)
+    ;;;; window-tool-bar
+    (window-tool-bar-button :background bg :foreground fg)
+    (window-tool-bar-button-hover :inherit 'highlight :distant-foreground bg)
+    (window-tool-bar-button-disabled :background bg-alt :foreground fg-alt)
     ;;;; winum
     (winum-face :inherit 'bold :foreground highlight)
     ;;;; woman <built-in>


### PR DESCRIPTION
This adds support for `window-tool-bar`, which is a new package in Emacs 30.

I'm not especially happy that "disabled" just looks borderless, but that's aligned with what the existing tab bar themes do. Ideally I'd like to have a desaturated version of fg/bg but I couldn't figure out how to do that.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
    - I tried here. Please let me know if you'd like any changes.
- [ ] My changes are visual; I've included before and after screenshots.
    - Let me know which theme to show screenshots for. I spot checked ~5 random ones since this affects the theme base.
- [ ] I am blindly checking these off.
    - I read the text. Not checking this. :) 
- [x] Any relevant issues or PRs have been linked to.
    - There are no relevant issues.
- [ ] This a draft PR; I need more time to finish it.