### PR TITLE
tweak(base): Inherit `flycheck-posframe-info-face` from `success`

### DIFF
--- a/doom-themes-base.el
+++ b/doom-themes-base.el
@@ -593,7 +593,7 @@
     (flycheck-posframe-face            :inherit 'default)
     (flycheck-posframe-background-face :background bg-alt)
     (flycheck-posframe-error-face      :inherit 'flycheck-posframe-face :foreground error)
-    (flycheck-posframe-info-face       :inherit 'flycheck-posframe-face :foreground fg)
+    (flycheck-posframe-info-face       :inherit 'flycheck-posframe-face :foreground success)
     (flycheck-posframe-warning-face    :inherit 'flycheck-posframe-face :foreground warning)
     ;;;; flymake
     (flymake-error   :underline `(:style wave :color ,red))


### PR DESCRIPTION
This will match the face foreground with that of
[`flycheck-fringe-info`][1] and [`doom-modeline-info`][2].

[1]: https://github.com/doomemacs/themes/blob/2c794a09b023bda09d2f36a7be80684f4e416d88/doom-themes-base.el#L591
[2]: https://github.com/seagle0128/doom-modeline/blob/b782f3c31b966c43fa281fd5fdd07d5c11579e25/doom-modeline-core.el#L780-L781
