### PR TITLE
fix(base): ansi-color-bright-black should be readable as foreground

### DIFF
--- a/doom-themes-base.el
+++ b/doom-themes-base.el
@@ -191,7 +191,12 @@
     (ansi-color-magenta        :foreground magenta :background magenta)
     (ansi-color-cyan           :foreground cyan    :background cyan)
     (ansi-color-white          :foreground fg      :background fg)
-    (ansi-color-bright-black   :foreground base0   :background base2)
+    ;; This color is used effectively as grayed out foreground text.
+    ;; base5 and up have too much contrast in light themes;
+    ;; base5 and lower have too little contrast in dark themes.
+    (ansi-color-bright-black
+     (&light :foreground base4 :background base4)
+     (&dark  :foreground base6 :background base6))
     (ansi-color-bright-red     :foreground (doom-lighten red 0.15)     :background (doom-lighten red 0.15))
     (ansi-color-bright-green   :foreground (doom-lighten green 0.15)   :background (doom-lighten green 0.15))
     (ansi-color-bright-yellow  :foreground (doom-lighten yellow 0.15)  :background (doom-lighten yellow 0.15))


### PR DESCRIPTION
<!-- ⚠️ Please do not ignore this template! -->

| Before | After |
|-|-|
| ![before](https://github.com/user-attachments/assets/fbd8151b-ec52-40b6-a92b-ce910d6cfe98) | ![after](https://github.com/user-attachments/assets/c7e5099b-cd02-4adc-a8d5-c7ccacec25b6) |

---

The "bright black" color is used in many tools for grayed out foreground text. For example

| Konsole, "One Dark", nodejs | Before (doom-nord, nodejs-repl) | After (doom-nord, nodejs-repl) |
|-|-|-|
| ![konsole nodejs one dark](https://github.com/user-attachments/assets/e201a551-8748-4fbd-b6b7-d6a5b83a1cb1) | ![emacs nodejs-repl nord before](https://github.com/user-attachments/assets/26f04f1b-166f-4dd6-a67d-557eacf3cd26) | ![emacs nodejs-repl nord after](https://github.com/user-attachments/assets/eb53034d-31d4-4d05-9d3b-55ce0a3f4e8c) |

See #833 for other examples.

So this color needs to be readable on all backgrounds, and cannot be the background color. This PR fixes that.

Fix: #833

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [x] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
