### PR TITLE
fix(tokyo-night): Italicise comments/keywords

### DIFF
--- a/themes/doom-tokyo-night-theme.el
+++ b/themes/doom-tokyo-night-theme.el
@@ -150,10 +150,12 @@
 
    (font-lock-comment-face
     :foreground comments
-    :background (if doom-tokyo-night-comment-bg (doom-lighten bg 0.05) 'unspecified))
+    :background (if doom-tokyo-night-comment-bg (doom-lighten bg 0.05) 'unspecified)
+    :slant 'italic)
    (font-lock-doc-face
     :inherit 'font-lock-comment-face
     :foreground doc-comments)
+   (font-lock-keyword-face :foreground keywords :slant 'italic)
 
    ;;; Doom Modeline
    (doom-modeline-bar :background (if -modeline-bright modeline-bg highlight))
@@ -170,6 +172,11 @@
     :foreground (if -modeline-bright base8 highlight))
    (mode-line-buffer-id
     :foreground highlight)
+
+   ;;; Doom Dashboard
+   (doom-dashboard-banner :foreground comments :slant 'normal)
+   (doom-dashboard-loaded :foreground comments :slant 'normal)
+   (doom-dashboard-menu-title :foreground magenta :slant 'normal)
 
    ;;; Indentation
    (whitespace-indentation :background bg)
@@ -271,6 +278,7 @@
    ;;; web-mode
    (web-mode-json-context-face :foreground brown)
    (web-mode-json-key-face :foreground teal)
+   (web-mode-keyword-face :inherit 'font-lock-keyword-face)
    ;;;; Block
    (web-mode-block-delimiter-face :foreground yellow)
    ;;;; Code
@@ -280,6 +288,8 @@
    (web-mode-css-pseudo-class-face :foreground orange)
    (web-mode-css-property-name-face :foreground blue)
    (web-mode-css-selector-face :foreground teal)
+   (web-mode-css-selector-class-face :foreground keywords :slant 'nil)
+   (web-mode-css-selector-tag-face :inherit 'web-mode-css-selector-class-face)
    (web-mode-css-function-face :foreground yellow)
    ;;;; HTML
    (web-mode-html-attr-engine-face :foreground yellow)


### PR DESCRIPTION
<!-- ⚠️ Please do not ignore this template! -->

#835 adds variants of Tokyo Night, including italic comments and keywords, which the existing Tokyo Night theme does not have. Making this consistent was deemed out of scope of that PR, so it's in this PR instead. Every line of delta was copied verbatim; the files are so similar I foresee no strangeness resulting from this.

Ref: #827

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ ] My changes are visual; I've included before and after screenshots.
- [x] Any relevant issues or PRs have been linked to.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
