### PR TITLE
nit: declare indenting rules for def-doom-themes

### DIFF
--- a/doom-themes.el
+++ b/doom-themes.el
@@ -418,7 +418,8 @@ theme face specs. These is a simplified spec. For example:
 
 (defmacro def-doom-theme (name docstring defs &optional extra-faces extra-vars)
   "Define a DOOM theme, named NAME (a symbol)."
-  (declare (doc-string 2))
+  (declare (doc-string 2)
+           (indent 2))
   (let ((doom-themes--colors defs))
     `(let* ((bold   doom-themes-enable-bold)
             (italic doom-themes-enable-italic)


### PR DESCRIPTION
The change makes elisp formatting more consistent with what is currently in `themes/`

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [x] ~~Any relevant issues or PRs have been linked to.~~
