### PR TITLE
Fix doom-homage themes

### DIFF
--- a/themes/doom-homage-black-theme.el
+++ b/themes/doom-homage-black-theme.el
@@ -179,9 +179,9 @@ determine the exact padding."
    ((org-todo &override) :foreground red)
    ;; make tags and dates to have pretty box around them
    ((org-tag &override)   :foreground fg :background base1
-    :box `(:line-width -1 :color ,base5 :style 'released-button))
+    :box `(:line-width -1 :color ,base5 :style released-button))
    ((org-date &override)  :foreground fg :background base1
-    :box `(:line-width -1 :color ,base5  :style 'released-button))
+    :box `(:line-width -1 :color ,base5 :style released-button))
    ;; Make drawers and special keywords (like scheduled) to be very bleak
    ((org-special-keyword &override)  :foreground grey)
    ((org-drawer          &override)  :foreground grey)

--- a/themes/doom-homage-white-theme.el
+++ b/themes/doom-homage-white-theme.el
@@ -184,9 +184,9 @@ determine the exact padding."
    ((org-todo &override) :foreground red)
    ;; Make tags and dates to have pretty box around them
    ((org-tag &override)   :foreground fg :background yellow-alt
-    :box `(:line-width -1 :color ,base5 :style 'released-button))
+    :box `(:line-width -1 :color ,base5 :style released-button))
    ((org-date &override)  :foreground fg :background base1
-    :box `(:line-width -1 :color ,base5  :style 'released-button))
+    :box `(:line-width -1 :color ,base5 :style released-button))
    ;; Make drawers and special keywords (like scheduled) to be very bleak
    ((org-special-keyword &override)  :foreground grey)
    ((org-drawer          &override)  :foreground grey)


### PR DESCRIPTION
```emacs-lisp
Debugger entered--Lisp error: (error "Invalid face box" :line-width -1 :color "#383a42" :style 'released-button)
  internal-set-lisp-face-attribute(org-date :box (:line-width -1 :color "#383a42" :style 'released-button) #<frame doom-homage-white-theme.el 0x13100ac40>)
  set-face-attribute(org-date #<frame doom-homage-white-theme.el 0x13100ac40> :foreground "#383a42" :background "#e7e7e7" :box (:line-width -1 :color "#383a42" :style 'released-button))
  apply(set-face-attribute org-date #<frame doom-homage-white-theme.el 0x13100ac40> (:foreground "#383a42" :background "#e7e7e7" :box (:line-width -1 :color "#383a42" :style 'released-button)))
  face-spec-set-2(org-date #<frame doom-homage-white-theme.el 0x13100ac40> (:foreground "#383a42" :background "#e7e7e7" :box (:line-width -1 :color "#383a42" :style 'released-button)))
  face-spec-recalc(org-date #<frame doom-homage-white-theme.el 0x13100ac40>)
  face-spec-set(org-date ((((class color) (background light)) (:foreground "Purple" :underline t)) (((class color) (background dark)) (:foreground "Cyan" :underline t)) (t (:underline t))) face-defface-spec)
  custom-declare-face(org-date ((((class color) (background light)) (:foreground "Purple" :underline t)) (((class color) (background dark)) (:foreground "Cyan" :underline t)) (t (:underline t))) ("/Users/wangtianshu/.config/emacs/straight/build/30.0/org/org-faces.elc" . 8217) :group org-faces)
  require(org-faces)
  byte-code("\301\302!\210\301\303!\210\10\304W\203\22\0\301\305!\210\301\306!\210\301\307!\210\301\310!\210\301\311!\210\301\312!\210\301\313!\210\301\314!\210\301\315!\207" [emacs-major-version require outline time-date 28 easymenu org-entities org-faces org-list org-pcomplete org-src org-footnote org-macro ob] 2)
  autoload-do-load((autoload "org" nil t nil) open-org-default-notes-file)
  command-execute(open-org-default-notes-file)
```