### PR TITLE
fix(base): replace :italic with :slant

### DIFF
--- a/doom-themes-base.el
+++ b/doom-themes-base.el
@@ -76,12 +76,12 @@
     (line-number
      :inherit 'default
      :foreground base5 :distant-foreground 'unspecified
-     :weight 'normal :italic 'unspecified
+     :weight 'normal :slant 'unspecified
      :underline 'unspecified :strike-through 'unspecified)
     (line-number-current-line
      :inherit '(hl-line default)
      :foreground fg :distant-foreground 'unspecified
-     :weight 'normal :italic 'unspecified
+     :weight 'normal :slant 'unspecified
      :underline 'unspecified :strike-through 'unspecified)
 
     ;;;; --- Package faces ----------------------
@@ -869,7 +869,7 @@
     (jdee-font-lock-doc-tag-face     :foreground violet)
     (jdee-font-lock-italic-face      :inherit 'italic)
     (jdee-font-lock-bold-face        :inherit 'bold)
-    (jdee-font-lock-link-face        :foreground blue :italic nil :underline t)
+    (jdee-font-lock-link-face        :foreground blue :slant nil :underline t)
     ;;;; js2-mode <modes:js2-mode,js2-jsx-mode>
     (js2-function-param    :foreground variables)
     (js2-function-call     :foreground functions)


### PR DESCRIPTION
`:italic` is not a font attribute

<!-- ⚠️ Please do not ignore this template! -->

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [x] My changes are visual; I've included before and after screenshots.

## Before
<img width="579" alt="Screenshot 2024-10-19 at 4 51 15 PM" src="https://github.com/user-attachments/assets/5d083cec-efd0-4e6f-a3c6-7bf2b1641226">


## After
<img width="579" alt="Screenshot 2024-10-19 at 4 52 23 PM" src="https://github.com/user-attachments/assets/fb3d5c68-4a4a-47ff-9093-85817a907257">
