### PR TITLE
fix(bluloco-light): Correct color for line numbers

### DIFF
--- a/themes/doom-bluloco-light-theme.el
+++ b/themes/doom-bluloco-light-theme.el
@@ -99,6 +99,10 @@
 
 (((font-lock-operator-face &override) :foreground dark-violet)
 
+   ;; line-number
+   (line-number :foreground comments)
+   (line-number-current-line :foreground comments)
+
    ;; mode-line
    (mode-line
     :background modeline-bg :foreground modeline-fg


### PR DESCRIPTION
Looking at the screenshots in

https://marketplace.visualstudio.com/items?itemName=uloco.theme-bluloco-light
https://github.com/uloco/theme-bluloco-light

one sees that in the VSCode theme the line numbers are not black but rather grey, like the comments.

Before:
![bluloco-light-before](https://github.com/user-attachments/assets/094ae456-b93c-4bad-8a2c-c866e80d84da)
After:
![bluloco-light-after](https://github.com/user-attachments/assets/03fe7030-0e30-41fb-8583-15b2951515bd)

-----
- [X] I searched the issue tracker and this hasn't been PRed before.
- [X] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [X] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.
- [ ] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
