### PR TITLE
fix(treemacs): inherit from variable-pitch face at most once

### DIFF
--- a/extensions/doom-themes-ext-treemacs.el
+++ b/extensions/doom-themes-ext-treemacs.el
@@ -107,7 +107,9 @@ Only takes effect if `doom-themes-treemacs-enable-variable-pitch' is non-nil."
         (set-face-attribute
          face nil :inherit
          `(,doom-themes-treemacs-variable-pitch-face
-           ,@(delq 'unspecified (if (listp faces) faces (list faces)))))))))
+           ,@(delq doom-themes-treemacs-variable-pitch-face
+                   (delq 'unspecified
+                         (if (listp faces) faces (list faces))))))))))
 
 (defun doom-themes-fix-treemacs-icons-dired-mode ()
   "Set `tab-width' to 1 in dired-mode if `treemacs-icons-dired-mode' is active."


### PR DESCRIPTION
The function `doom-themes-enable-treemacs-variable-pitch-labels` is
executed every time `load-theme` gets called.

Before this fix, each invocation would lead to the treemacs-*-faces
gaining an `:inherit doom-themes-treemacs-variable-pitch-face`
attribute. But inheriting from a face is not an idempotent operation,
i.e., applying it more than once will lead to a different effect than
applying it exactly once. For instance, if the face `variable-pitch` has
the attribute `:height 1.2`, then inheriting from it 4 times will lead
to a height of 1.2^4 ≈ 2 instead of 1.2. Loading 4 themes will therefore
inadvertently double the font size in the treemacs buffer.

With this fix, the inheritance is only applied once.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
