### PR TITLE
fix(zenburn-light) :freground -> :foreground

### DIFF
--- a/themes/doom-zenburn-theme.el
+++ b/themes/doom-zenburn-theme.el
@@ -154,7 +154,7 @@ Can be an integer to determine the exact padding."
    (font-lock-warning-face :foreground yellow-1 :weight 'bold)
    (font-lock-keyword-face :foreground yellow :weight 'bold)
    (highlight :background base4)
-   (isearch :freground yellow-2 :weight 'bold :background base6)
+   (isearch :foreground yellow-2 :weight 'bold :background base6)
    (isearch-fail :foreground fg :background red-4)
    (lazy-highlight :foreground yellow-2 :weight 'bold :background base3)
    ((line-number &override) :foreground base7)


### PR DESCRIPTION
Fix misspelling of foreground resulting in faulty foreground for isearch using zenburn-light theme

- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [ ] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).