### PR TITLE
feat(treemacs): replace all-the-icons by nerd-icons

### DIFF
--- a/extensions/doom-themes-ext-treemacs.el
+++ b/extensions/doom-themes-ext-treemacs.el
@@ -34,7 +34,7 @@ See `doom-themes-treemacs-variable-pitch-face'."
 (defcustom doom-themes-treemacs-theme "doom-atom"
   "Default treemacs theme."
   :type '(radio (const :doc "A minimalistic atom-inspired icon theme" "doom-atom")
-                (const :doc "A colorful icon theme leveraging all-the-icons" "doom-colors"))
+                (const :doc "A colorful icon theme leveraging nerd-icons" "doom-colors"))
   :group 'doom-themes-treemacs)
 
 (defcustom doom-themes-treemacs-bitmap-indicator-width 3
@@ -119,8 +119,8 @@ Only takes effect if `doom-themes-treemacs-enable-variable-pitch' is non-nil."
 ;;; Bootstrap
 
 (with-eval-after-load 'treemacs
-  (unless (require 'all-the-icons nil t)
-    (error "all-the-icons isn't installed"))
+  (unless (require 'nerd-icons nil t)
+    (error "nerd-icons isn't installed"))
 
   (add-hook 'treemacs-mode-hook #'doom-themes-setup-tab-width)
   (add-hook 'treemacs-mode-hook #'doom-themes-setup-line-spacing)
@@ -147,49 +147,49 @@ Only takes effect if `doom-themes-treemacs-enable-variable-pitch' is non-nil."
       :config
       (progn
         (treemacs-create-icon
-         :icon (format " %s\t" (all-the-icons-octicon "repo" :height 1.2 :v-adjust -0.1 :face 'doom-themes-treemacs-root-face))
+         :icon (format " %s\t" (nerd-icons-octicon "nf-oct-repo" :height 1.2 :v-adjust -0.1 :face 'doom-themes-treemacs-root-face))
          :extensions (root-open))
         (treemacs-create-icon
-         :icon (format " %s\t" (all-the-icons-octicon "repo" :height 1.2 :v-adjust -0.1 :face 'doom-themes-treemacs-root-face))
+         :icon (format " %s\t" (nerd-icons-octicon "nf-oct-repo" :height 1.2 :v-adjust -0.1 :face 'doom-themes-treemacs-root-face))
          :extensions (root-closed))
         (treemacs-create-icon
          :icon (format "%s\t%s\t"
-                       (all-the-icons-octicon "chevron-down" :height 0.75 :v-adjust 0.1 :face face-spec)
-                       (all-the-icons-octicon "file-directory" :v-adjust 0 :face face-spec))
+                       (nerd-icons-octicon "nf-oct-chevron_down" :height 0.75 :v-adjust 0.1 :face face-spec)
+                       (nerd-icons-octicon "nf-oct-file_directory" :v-adjust 0 :face face-spec))
          :extensions (dir-open))
         (treemacs-create-icon
          :icon (format "%s\t%s\t"
-                       (all-the-icons-octicon "chevron-right" :height 0.75 :v-adjust 0.1 :face face-spec)
-                       (all-the-icons-octicon "file-directory" :v-adjust 0 :face face-spec))
+                       (nerd-icons-octicon "nf-oct-chevron_right" :height 0.75 :v-adjust 0.1 :face face-spec)
+                       (nerd-icons-octicon "nf-oct-file_directory" :v-adjust 0 :face face-spec))
          :extensions (dir-closed))
         (treemacs-create-icon
          :icon (format "%s\t%s\t"
-                       (all-the-icons-octicon "chevron-down" :height 0.75 :v-adjust 0.1 :face face-spec)
-                       (all-the-icons-octicon "package" :v-adjust 0 :face face-spec)) :extensions (tag-open))
+                       (nerd-icons-octicon "nf-oct-chevron_down" :height 0.75 :v-adjust 0.1 :face face-spec)
+                       (nerd-icons-octicon "nf-oct-package" :v-adjust 0 :face face-spec)) :extensions (tag-open))
         (treemacs-create-icon
          :icon (format "%s\t%s\t"
-                       (all-the-icons-octicon "chevron-right" :height 0.75 :v-adjust 0.1 :face face-spec)
-                       (all-the-icons-octicon "package" :v-adjust 0 :face face-spec))
+                       (nerd-icons-octicon "nf-oct-chevron_right" :height 0.75 :v-adjust 0.1 :face face-spec)
+                       (nerd-icons-octicon "nf-oct-package" :v-adjust 0 :face face-spec))
          :extensions (tag-closed))
         (treemacs-create-icon
-         :icon (format "%s\t" (all-the-icons-octicon "tag" :height 0.9 :v-adjust 0 :face face-spec))
+         :icon (format "%s\t" (nerd-icons-octicon "nf-oct-tag" :height 0.9 :v-adjust 0 :face face-spec))
          :extensions (tag-leaf))
         (treemacs-create-icon
-         :icon (format "%s\t" (all-the-icons-octicon "flame" :v-adjust 0 :face face-spec))
+         :icon (format "%s\t" (nerd-icons-octicon "nf-oct-flame" :v-adjust 0 :face face-spec))
          :extensions (error))
         (treemacs-create-icon
-         :icon (format "%s\t" (all-the-icons-octicon "stop" :v-adjust 0 :face face-spec))
+         :icon (format "%s\t" (nerd-icons-octicon "nf-oct-stop" :v-adjust 0 :face face-spec))
          :extensions (warning))
         (treemacs-create-icon
-         :icon (format "%s\t" (all-the-icons-octicon "info" :height 0.75 :v-adjust 0.1 :face face-spec))
+         :icon (format "%s\t" (nerd-icons-octicon "nf-oct-info" :height 0.75 :v-adjust 0.1 :face face-spec))
          :extensions (info))
         (treemacs-create-icon
-         :icon (format "  %s\t" (all-the-icons-octicon "file-media" :v-adjust 0 :face face-spec))
+         :icon (format "  %s\t" (nerd-icons-octicon "nf-oct-file_media" :v-adjust 0 :face face-spec))
          :extensions ("ai" "aiff" "avi" "bmp" "eps" "flac" "gif" "ico" "indd"
                       "jpeg" "jpg" "midi" "mkv" "mov" "mp3" "mp4" "ogg" "png"
                       "psd" "svg" "tif" "tiff" "wav" "webm" "webp"))
         (treemacs-create-icon
-         :icon (format "  %s\t" (all-the-icons-octicon "file-code" :v-adjust 0 :face face-spec))
+         :icon (format "  %s\t" (nerd-icons-octicon "nf-oct-file_code" :v-adjust 0 :face face-spec))
          :extensions ("accdb" "accdt" "actionscript" "adoc" "adoc" "ansible"
                       "antlr" "applescript" "asciidoc" "asm" "c" "cask" "cc"
                       "cc" "clj" "cljc" "cljs" "cmake" "coffee" "cpp" "css"
@@ -211,7 +211,7 @@ Only takes effect if `doom-themes-treemacs-enable-variable-pitch' is non-nil."
                       "vagrantfile" "vh" "vhd" "vhdl" "vhms" "vim" "vue" "xsl"
                       "zsh" "zshrc"))
         (treemacs-create-icon
-         :icon (format "  %s\t" (all-the-icons-octicon "book" :v-adjust 0 :face face-spec))
+         :icon (format "  %s\t" (nerd-icons-octicon "nf-oct-book" :v-adjust 0 :face face-spec))
          :extensions ("azw" "azw3" "cb7" "cba" "cbr" "cbt" "cbz" "ceb" "chm"
                       "djvu" "doc" "docx" "exe" "fb2" "inf" "kf8" "kfx" "lit"
                       "lrf" "lrx" "mobi" "opf" "or" "oxps" "pdb" "pdb" "pdb"
@@ -219,7 +219,7 @@ Only takes effect if `doom-themes-treemacs-enable-variable-pitch' is non-nil."
                       "pot" "potx" "potm" "pps" "ppsx" "ppsm" "ppt" "pptx"
                       "pptm" "pa" "ppa" "ppam" "sldm" "sldx" ))
         (treemacs-create-icon
-         :icon (format "  %s\t" (all-the-icons-faicon "cogs" :height 0.85 :v-adjust 0 :face face-spec))
+         :icon (format "  %s\t" (nerd-icons-faicon "nf-fa-cogs" :height 0.85 :v-adjust 0 :face face-spec))
          :extensions ("Vagrantfile" "babel.config.js" "babelignore" "babelrc"
                       "babelrc.js" "babelrc.json" "bashrc" "bazel" "bazelrc"
                       "bower.json" "bowerrc" "cabal" "cfg" "conf" "config"
@@ -234,22 +234,22 @@ Only takes effect if `doom-themes-treemacs-enable-variable-pitch' is non-nil."
                       "xresources" "yaml" "yarn-integrity" "yarnclean"
                       "yarnignore" "yarnrc" "yml"))
         (treemacs-create-icon
-         :icon (format "  %s\t" (all-the-icons-octicon "file-text" :v-adjust 0 :face face-spec))
+         :icon (format "  %s\t" (nerd-icons-octicon "nf-oct-file" :v-adjust 0 :face face-spec))
          :extensions ("md" "markdown" "rst" "org" "log" "txt" "contribute"
                       "license" "readme" "changelog"))
         (treemacs-create-icon
-         :icon (format "  %s\t" (all-the-icons-octicon "file-binary" :v-adjust 0 :face face-spec))
+         :icon (format "  %s\t" (nerd-icons-octicon "nf-oct-file_binary" :v-adjust 0 :face face-spec))
          :extensions ("exe" "dll" "obj" "so" "o" "out" "elc" "cmake-cache" "csr"
                       "eslintcache" "crt" "cer" "der" "pfx" "p12" "p7b" "p7r"
                       "DS_STORE" "key" "pem" "src" "crl" "sst" "stl" "ipynb"))
         (treemacs-create-icon
-         :icon (format "  %s\t" (all-the-icons-octicon "file-pdf" :v-adjust 0 :face face-spec))
+         :icon (format "  %s\t" (nerd-icons-faicon "nf-fa-file_pdf" :v-adjust 0 :face face-spec))
          :extensions ("pdf"))
         (treemacs-create-icon
-         :icon (format "  %s\t" (all-the-icons-octicon "file-zip" :v-adjust 0 :face face-spec))
+         :icon (format "  %s\t" (nerd-icons-octicon "nf-oct-file_zip" :v-adjust 0 :face face-spec))
          :extensions ("zip" "xz" "7z" "tar" "gz" "rar" "tgz" "jar"))
         (treemacs-create-icon
-         :icon (format "  %s\t" (all-the-icons-octicon "file-text" :v-adjust 0 :face face-spec))
+         :icon (format "  %s\t" (nerd-icons-octicon "nf-oct-file" :v-adjust 0 :face face-spec))
          :extensions (fallback))))
 
     (treemacs-create-theme "doom-colors"
@@ -257,28 +257,28 @@ Only takes effect if `doom-themes-treemacs-enable-variable-pitch' is non-nil."
       :config
       (progn
         (treemacs-create-icon
-         :icon (format " %s\t" (all-the-icons-octicon "repo" :height 1.2 :v-adjust -0.1 :face 'doom-themes-treemacs-root-face))
+         :icon (format " %s\t" (nerd-icons-octicon "nf-oct-repo" :height 1.2 :v-adjust -0.1 :face 'doom-themes-treemacs-root-face))
          :extensions (root-open))
         (treemacs-create-icon
-         :icon (format " %s\t" (all-the-icons-octicon "repo" :height 1.2 :v-adjust -0.1 :face 'doom-themes-treemacs-root-face))
+         :icon (format " %s\t" (nerd-icons-octicon "nf-oct-repo" :height 1.2 :v-adjust -0.1 :face 'doom-themes-treemacs-root-face))
          :extensions (root-closed))
         (treemacs-create-icon
-         :icon (format "%s\t" (all-the-icons-octicon "flame" :height 0.8 :v-adjust 0 :face 'all-the-icons-red))
+         :icon (format "%s\t" (nerd-icons-octicon "nf-oct-flame" :height 0.8 :v-adjust 0 :face 'nerd-icons-red))
          :extensions (error))
         (treemacs-create-icon
-         :icon (format "%s\t" (all-the-icons-octicon "stop" :height 0.8 :v-adjust 0 :face 'all-the-icons-yellow))
+         :icon (format "%s\t" (nerd-icons-octicon "nf-oct-stop" :height 0.8 :v-adjust 0 :face 'nerd-icons-yellow))
          :extensions (warning))
         (treemacs-create-icon
-         :icon (format "%s\t" (all-the-icons-octicon "info" :height 0.75 :v-adjust 0.1 :face 'all-the-icons-green))
+         :icon (format "%s\t" (nerd-icons-octicon "nf-oct-info" :height 0.75 :v-adjust 0.1 :face 'nerd-icons-green))
          :extensions (info))
         (treemacs-create-icon
-         :icon (format "  %s\t" (all-the-icons-alltheicon "git" :height 0.85 :v-adjust 0.0 :face 'all-the-icons-red))
+         :icon (format "  %s\t" (nerd-icons-faicon "nf-fa-git_alt" :height 0.85 :v-adjust 0.0 :face 'nerd-icons-red))
          :extensions ("gitignore" "git" "gitattributes" "gitconfig" "gitmodules"))
         (treemacs-create-icon
-         :icon (format "%s\t" (all-the-icons-octicon "book" :height 1.0 :v-adjust 0.0 :face 'all-the-icons-blue))
+         :icon (format "%s\t" (nerd-icons-octicon "nf-oct-book" :height 1.0 :v-adjust 0.0 :face 'nerd-icons-blue))
          :extensions (license))
 
-        (dolist (item all-the-icons-extension-icon-alist)
+        (dolist (item nerd-icons-extension-icon-alist)
           (let* ((extension (car item))
                  (func (cadr item))
                  (args (append (list (cadr (cdr item))) '(:v-adjust -0.05 :height 0.85) (cdr (cddr item))))
@@ -295,10 +295,10 @@ Only takes effect if `doom-themes-treemacs-enable-variable-pitch' is non-nil."
         ;; regexp is too complicated to be reversed with
         ;; `doom-themes--get-treemacs-extensions' -- which is too naive)
         (treemacs-create-icon
-         :icon (format "  %s\t" (all-the-icons-fileicon "R" :v-adjust 0 :face 'all-the-icons-dblue))
+         :icon (format "  %s\t" (nerd-icons-faicon "nf-fa-r_project" :v-adjust 0 :face 'nerd-icons-dblue))
          :extensions ("r"))
         (treemacs-create-icon
-         :icon (format "  %s\t" (all-the-icons-octicon "file-code" :v-adjust 0 :face face-spec))
+         :icon (format "  %s\t" (nerd-icons-octicon "nf-oct-file_code" :v-adjust 0 :face face-spec))
          :extensions ("elc")))))
 
   (treemacs-load-theme doom-themes-treemacs-theme))


### PR DESCRIPTION
Some missing icons have been replaced by similar alternatives:
- octicon file-pdf has been replaced by faicon file_pdf
- octicon file-text has been replaced by octicon file
- alltheicon git has been replaced by faicon git_alt
- fileicon R has been replace by faicon r_project

- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [!] My changes are visual; I've included before and after screenshots. @sebastiaanspeck counting on you ;)
- [ ] I am blindly checking these off.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

Similar merged MR for neotree https://github.com/doomemacs/themes/pull/816