### PR TITLE
fix ediff highlights for all themes

### DIFF
--- a/doom-themes-base.el
+++ b/doom-themes-base.el
@@ -491,11 +491,11 @@
     ;;;; doom-themes
     (doom-themes-visual-bell :background error)
     ;;;; ediff <built-in>
-    (ediff-fine-diff-A    :background (doom-blend selection bg 0.7) :weight 'bold :extend t)
-    (ediff-fine-diff-B    :inherit 'ediff-fine-diff-A)
+    (ediff-fine-diff-A    :inherit 'diff-refine-removed)
+    (ediff-fine-diff-B    :inherit 'diff-refine-added)
     (ediff-fine-diff-C    :inherit 'ediff-fine-diff-A)
-    (ediff-current-diff-A :background (doom-blend selection bg 0.3) :extend t)
-    (ediff-current-diff-B :inherit 'ediff-current-diff-A)
+    (ediff-current-diff-A :foreground vc-deleted :background (doom-blend vc-deleted base3 0.2)  :extend t)
+    (ediff-current-diff-B :foreground vc-added   :background (doom-blend vc-added bg 0.2)       :extend t)
     (ediff-current-diff-C :inherit 'ediff-current-diff-A)
     (ediff-even-diff-A    :inherit 'hl-line)
     (ediff-even-diff-B    :inherit 'ediff-even-diff-A)

--- a/themes/doom-fairy-floss-theme.el
+++ b/themes/doom-fairy-floss-theme.el
@@ -150,6 +150,9 @@ determine the exact padding."
    (css-selector             :foreground blue)
    ;;;; doom-modeline
    (doom-modeline-bar :background blue)
+   ;;;; ediff
+   (ediff-current-diff-A :background (doom-blend red base5 0.2) :foreground red)
+   (ediff-fine-diff-A    :background (doom-blend red base5 0.3) :foreground red :weight 'bold)
    ;;;; elscreen
    (elscreen-tab-other-screen-face :background "#353a42" :foreground "#1e2022")
    ;;;; highlight-symbol

--- a/themes/doom-meltbus-theme.el
+++ b/themes/doom-meltbus-theme.el
@@ -163,6 +163,8 @@ highlight interactive elements."
    (doom-modeline-evil-normal-state :foreground base5)
    (doom-modeline-evil-visual-state :foreground white)
    (doom-modeline-evil-operator-state :inherit 'doom-modeline-evil-visual-state)
+   ;;;; ediff
+   (ediff-current-diff-B :foreground green :background (doom-lighten green 0.8))
    ;;;; evil
    ((evil-ex-substitute-replacement &override) :foreground cyan)
    ;;;; evil-snipe

--- a/themes/doom-nord-aurora-theme.el
+++ b/themes/doom-nord-aurora-theme.el
@@ -175,10 +175,6 @@ determine the exact padding."
     :background modeline-bg-inactive-l
     :box (if -modeline-pad `(:line-width ,-modeline-pad :color ,modeline-bg-inactive-l)))
 
-   ;; ediff
-   (ediff-fine-diff-A    :background (doom-darken violet 0.4) :weight 'bold)
-   (ediff-current-diff-A :background (doom-darken base0 0.25))
-
    ;; elscreen
    (elscreen-tab-other-screen-face :background "#353a42" :foreground "#1e2022")
 

--- a/themes/doom-nord-theme.el
+++ b/themes/doom-nord-theme.el
@@ -161,9 +161,6 @@ determine the exact padding."
    ;;;; doom-modeline
    (doom-modeline-bar :background (if -modeline-bright modeline-bg highlight))
    (doom-modeline-project-root-dir :foreground base6)
-   ;;;; ediff <built-in>
-   (ediff-fine-diff-A    :background (doom-darken violet 0.4) :weight 'bold)
-   (ediff-current-diff-A :background (doom-darken base0 0.25))
    ;;;; elscreen
    (elscreen-tab-other-screen-face :background "#353a42" :foreground "#1e2022")
    ;;;; highlight-symbol


### PR DESCRIPTION
Ediff colors inherited the same values making it hard to distinguish additions, deletions and fine diffs for most of the themes. `doom-one-light`, for example, solves the issue for itself, but this change tries to fix it for all the themes.

This is the sample before and after for `doom-nord-aurora`
Before:
<img width="2974" height="534" alt="Screenshot 2025-08-30 at 6 38 02 PM" src="https://github.com/user-attachments/assets/6124c0f3-41de-41c5-ba3b-dbc9a891db3a" />
After:

<img width="2978" height="622" alt="Screenshot 2025-08-30 at 6 39 53 PM" src="https://github.com/user-attachments/assets/012c84d3-7000-43c2-9824-dd3a76de2bf0" />



Following is the video demonstrating the new view for all the themes.

https://github.com/user-attachments/assets/c169fb46-5e2d-48dc-aa56-ed0132b109ef


The PR also makes minor adjustments in themes where the default values don't look proper. These themes are:
- `doom-nord-aurora`
- `doom-nord`
- `doom-meltbus`
- `doom-fairyfloss`


Fix: #847, #792


<!-- ⚠️ Please do not ignore this template! -->



-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.
- [x] Any relevant issues or PRs have been linked to.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
